### PR TITLE
Add classpath resource resolver, support file uri in logo

### DIFF
--- a/src/main/java/io/alapierre/ksef/fop/ClasspathResourceResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/ClasspathResourceResolver.java
@@ -1,0 +1,55 @@
+package io.alapierre.ksef.fop;
+
+import org.apache.fop.apps.io.ResourceResolverFactory;
+import org.apache.xmlgraphics.io.Resource;
+import org.apache.xmlgraphics.io.ResourceResolver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+public class ClasspathResourceResolver implements ResourceResolver {
+
+    private final ResourceResolver delegate;
+
+    public ClasspathResourceResolver() {
+        this.delegate = ResourceResolverFactory.createDefaultResourceResolver();
+    }
+
+    @Override
+    public Resource getResource(URI uri) throws IOException {
+        if (classpath(uri)) {
+            String path = uri.getSchemeSpecificPart();
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+
+            final InputStream is = Thread.currentThread()
+                    .getContextClassLoader()
+                    .getResourceAsStream(path);
+
+            if (is == null) {
+                throw new IllegalArgumentException("Classpath resource not found: " + uri);
+            }
+
+            return new Resource(is);
+        }
+
+        // fallback to default FOP resolver
+        return delegate.getResource(uri);
+    }
+
+    @Override
+    public OutputStream getOutputStream(URI uri) throws IOException {
+        if (classpath(uri)) {
+            throw new UnsupportedOperationException("Writing to classpath resources is not supported: " + uri);
+        }
+
+        return delegate.getOutputStream(uri);
+    }
+
+    private static boolean classpath(URI uri) {
+        return uri != null && "classpath".equals(uri.getScheme());
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.net.URI;
 import java.time.LocalDate;
 
 @Data
@@ -18,6 +19,8 @@ public class InvoiceGenerationParams {
     private String verificationLink;
 
     private byte[] logo;
+
+    private URI logoUri;
 
     @Nullable
     private LocalDate currencyDate;

--- a/src/main/resources/templates/fa3/ksef_invoice.xsl
+++ b/src/main/resources/templates/fa3/ksef_invoice.xsl
@@ -89,6 +89,7 @@
     <xsl:param name="qrCode"/>
     <xsl:param name="verificationLink"/>
     <xsl:param name="logo"/>
+    <xsl:param name="logoUri"/>
     <xsl:param name="showFooter"/>
     <xsl:param name="duplicateDate"/>
     <xsl:param name="currencyDate"/>
@@ -172,7 +173,13 @@
                             <fo:external-graphic
                                     content-width="80pt"
                                     content-height="80pt"
-                                    src="url('data:image/png;base64,{$logo}')"/>
+                                    src="url('data:image/svg;base64,{$logo}')"/>
+                        </xsl:if>
+                        <xsl:if test="$logoUri != ''">
+                            <fo:external-graphic
+                                    content-width="80pt"
+                                    content-height="80pt"
+                                    src="url('{$logoUri}')"/>
                         </xsl:if>
                     </fo:block>
                     <!-- Numer faktury -->


### PR DESCRIPTION
### Description

This PR provides the following enhancements:
- class path resource support both in `fop.xconf` and also `xsl` templates. Allows to reference URIs like `classpath:fop/some-logo.svg`.
- new invoice generation param - `logoUri`. Also brings classpath support and allows to use different images (e.g. `svg`) without having to load the file to a byte array up front.

While this PR allows me to not use `InputStream` constructor, I have still added `InvoicePdfConfig` to the `PdfGenerator` -> resolves https://github.com/ksef4dev/ksef-fop/issues/42.

**Note** - this is just a draft without any tests. I would first like to understand if you can accept all of these changes. Happy to add all remaining parts afterwards.

### References

- https://github.com/ksef4dev/ksef-fop/issues/42