### PR TITLE
Update SonarQube configuration and refine GitHub Actions workflows

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -19,11 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository (same commit as Build)
+      - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download coverage, test results and binary artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # 7.0.0


### PR DESCRIPTION
Currently Sonar treat test code as production code, this makes lot of false positive finding. And also - using head_sha ensures that SonarCloud analyzes exactly the same sources that were compiled and tested in the Build workflow. This is required for correct PR decoration and proper separation of test and production code.

Added `sonar.sources`, `sonar.tests`, and `sonar.test.inclusions` configurations for improved SonarQube analysis. Adjusted the `sonar.yml` workflow to ensure the repository checkout matches the build commit for consistency.

