### PR TITLE
#45 Add GitHub Actions workflow for automated release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: mvn -B -DskipTests package
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # 2.5.0
         with:
           generate_release_notes: true
           files: |


### PR DESCRIPTION
publish a GitHub Release for each ksef-fop version that is released to Maven Central