### PR TITLE
Minimize widths of CN/PKOB/GTIN/PKWiU columns

### DIFF
--- a/src/main/resources/templates/fa3/invoice-rows.xsl
+++ b/src/main/resources/templates/fa3/invoice-rows.xsl
@@ -23,11 +23,14 @@
     <xsl:attribute-set name="tableBorder">
         <xsl:attribute name="border">solid 0.2mm black</xsl:attribute>
     </xsl:attribute-set>
+    <xsl:variable name="tableHeaderFontSize" select="7"/>
+    <xsl:variable name="tableRowFontSize" select="7"/>
+    <xsl:variable name="tableFontSize" select="max(($tableHeaderFontSize, $tableRowFontSize))"/>
     <xsl:attribute-set name="tableHeaderFont">
-        <xsl:attribute name="font-size">7</xsl:attribute>
+        <xsl:attribute name="font-size" select="concat($tableHeaderFontSize, 'pt')"/>
     </xsl:attribute-set>
     <xsl:attribute-set name="tableFont">
-        <xsl:attribute name="font-size">7</xsl:attribute>
+        <xsl:attribute name="font-size" select="concat($tableRowFontSize, 'pt')"/>
     </xsl:attribute-set>
     <xsl:attribute-set name="table.cell.padding">
         <xsl:attribute name="padding-left">4pt</xsl:attribute>
@@ -36,172 +39,207 @@
         <xsl:attribute name="padding-bottom">4pt</xsl:attribute>
     </xsl:attribute-set>
 
+    <!-- Template to create the columns and header row of the table -->
+    <xsl:template name="tableHeader">
+        <xsl:param name="hasIndeks"      as="xs:boolean"/>
+        <xsl:param name="hasGTIN"        as="xs:boolean"/>
+        <xsl:param name="hasPKWiU"       as="xs:boolean"/>
+        <xsl:param name="hasCN"          as="xs:boolean"/>
+        <xsl:param name="hasPKOB"        as="xs:boolean"/>
+        <xsl:param name="hasKwotaAkcyzy" as="xs:boolean"/>
+        <xsl:param name="hasP9A"         as="xs:boolean"/>
+        <xsl:param name="hasP9B"         as="xs:boolean"/>
+        <xsl:param name="hasP10"         as="xs:boolean"/>
+        <xsl:param name="hasP12"         as="xs:boolean"/>
+        <xsl:param name="hasP11"         as="xs:boolean"/>
+        <xsl:param name="hasP11Vat"      as="xs:boolean"/>
+        <xsl:param name="hasP11A"        as="xs:boolean"/>
+        <xsl:param name="hasP6A"         as="xs:boolean"/>
+
+        <!--
+          In the table below, we approximate the size of some columns width fixed or almost fixed width.
+          Other columns are expressed as percentage of table.
+          Finally, `Nazwa` takes up the remaining space.
+
+          For evaluation purposes:
+          - 1 digit = 0.6em (0.5718 in OpenSans)
+          - 1 dot or space = 0.3em (0.2661 in OpenSans)
+          - 1.2em padding added
+
+          If label is larger, we expand to fit the label.
+
+          Field         Width    Max chars
+          ───────────────────────────────────────────────────────
+          CN            6.3em      CN code: 8 digits with optional space
+          GTIN          9.0em      GTIN: 13 digits for EAN
+          PKOB          4.0em      PKOB code: up to 4 digits (e.g. "0000"), label is larger
+          PKWiU         6.3em      PKWiU code: up to 7 digits (e.g. "00.00.00.0")
+          ───────────────────────────────────────────────────────
+        -->
+        <fo:table-column column-width="4%"/> <!-- Lp. -->
+        <xsl:if test="$hasIndeks">
+            <fo:table-column column-width="8%"/> <!-- Indeks -->
+        </xsl:if>
+        <xsl:if test="$hasGTIN">
+            <fo:table-column column-width="9.0em"/> <!-- GTIN -->
+        </xsl:if>
+        <xsl:if test="$hasPKWiU">
+            <fo:table-column column-width="6.3em"/> <!-- PKWiU -->
+        </xsl:if>
+        <xsl:if test="$hasCN">
+            <fo:table-column column-width="6.3em"/> <!-- CN -->
+        </xsl:if>
+        <xsl:if test="$hasPKOB">
+            <fo:table-column column-width="4.0em"/> <!-- PKOB -->
+        </xsl:if>
+        <xsl:if test="$hasKwotaAkcyzy">
+            <fo:table-column column-width="8%"/> <!-- Kwota akcyzy -->
+        </xsl:if>
+        <fo:table-column column-width="proportional-column-width(1)"/> <!-- Nazwa -->
+        <fo:table-column column-width="8%"/> <!-- Ilość -->
+        <fo:table-column column-width="5%"/> <!-- Jednostka -->
+        <xsl:if test="$hasP9A">
+            <fo:table-column column-width="10%"/> <!-- Cena jednostkowa netto -->
+        </xsl:if>
+        <xsl:if test="$hasP9B">
+            <fo:table-column column-width="10%"/> <!-- Cena jednostkowa brutto -->
+        </xsl:if>
+        <xsl:if test="$hasP10">
+            <fo:table-column column-width="7%"/> <!-- Rabat -->
+        </xsl:if>
+        <xsl:if test="$hasP12">
+            <fo:table-column column-width="8%"/> <!-- Stawka podatku -->
+        </xsl:if>
+        <xsl:if test="$hasP11">
+            <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży netto -->
+        </xsl:if>
+        <xsl:if test="$hasP11Vat">
+            <fo:table-column column-width="7%"/> <!-- Kwota VAT -->
+        </xsl:if>
+        <xsl:if test="$hasP11A">
+            <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży brutto -->
+        </xsl:if>
+        <xsl:if test="$hasP6A">
+            <fo:table-column column-width="9%"/> <!-- Data dostawy (P_6A) -->
+        </xsl:if>
+
+        <!-- Table header -->
+        <fo:table-header>
+            <fo:table-row background-color="#f5f5f5" font-weight="bold">
+                <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                    <fo:block><xsl:value-of select="key('kLabels', 'row.lp', $labels)"/></fo:block>
+                </fo:table-cell>
+                <xsl:if test="$hasIndeks">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.indeks', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasGTIN">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.gtin', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasPKWiU">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.pkwiu', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasCN">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.cn', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasPKOB">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.pkob', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasKwotaAkcyzy">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.exciseAmount', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                    <fo:block><xsl:value-of select="key('kLabels', 'row.productName', $labels)"/></fo:block>
+                </fo:table-cell>
+                <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                    <fo:block><xsl:value-of select="key('kLabels', 'row.quantity', $labels)"/></fo:block>
+                </fo:table-cell>
+                <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                    <fo:block><xsl:value-of select="key('kLabels', 'row.unit', $labels)"/></fo:block>
+                </fo:table-cell>
+                <xsl:if test="$hasP9A">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceNet', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP9B">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceGross', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP10">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.discount', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP12">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.taxRate', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP11">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.netValue', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP11Vat">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.vatAmount', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP11A">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.grossValue', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+                <xsl:if test="$hasP6A">
+                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
+                        <fo:block><xsl:value-of select="key('kLabels', 'row.deliveryDate', $labels)"/></fo:block>
+                    </fo:table-cell>
+                </xsl:if>
+            </fo:table-row>
+        </fo:table-header>
+    </xsl:template>
+
     <!-- Template for rendering the positions table -->
     <xsl:template name="positionsTable">
         <xsl:param name="faWiersz"/>
 
-        <!-- Calculate column width for name based on presence of other columns -->
-        <!-- Fixed columns: Lp (4%), Quantity (8%), Unit (5%) = 17% -->
-        <!-- Optional columns: Indeks (8%), GTIN/PKWiU (5%), PKOB (6%), CN (6%), KwotaAkcyzy (8%), P_6A (9%), P_9A (10%), P_9B (10%), P_10 (7%), P_12 (8%), P_11 (10%), P_11Vat (7%), P_11A (10%) -->
-        <xsl:variable name="nameColumnWidth">
-            <xsl:variable name="fixedWidth" select="17"/> <!-- Lp + Quantity + Unit -->
-            <xsl:variable name="indeksWidth" select="if ($faWiersz/crd:Indeks) then 8 else 0"/>
-            <xsl:variable name="gtinWidth" select="if ($faWiersz/crd:GTIN) then 5 else 0"/>
-            <xsl:variable name="pkwiuWidth" select="if ($faWiersz/crd:PKWiU) then 5 else 0"/>
-            <xsl:variable name="cnWidth" select="if ($faWiersz/crd:CN) then 6 else 0"/>
-            <xsl:variable name="pkobWidth" select="if ($faWiersz/crd:PKOB) then 6 else 0"/>
-            <xsl:variable name="kwotaAkcyzyWidth" select="if ($faWiersz/crd:KwotaAkcyzy) then 8 else 0"/>
-            <xsl:variable name="p6aWidth" select="if ($faWiersz/crd:P_6A) then 9 else 0"/>
-            <xsl:variable name="p9aWidth" select="if ($faWiersz/crd:P_9A) then 10 else 0"/>
-            <xsl:variable name="p9bWidth" select="if ($faWiersz/crd:P_9B) then 10 else 0"/>
-            <xsl:variable name="p10Width" select="if ($faWiersz/crd:P_10) then 7 else 0"/>
-            <xsl:variable name="p12Width" select="if ($faWiersz/crd:P_12) then 8 else 0"/>
-            <xsl:variable name="p11Width" select="if ($faWiersz/crd:P_11) then 10 else 0"/>
-            <xsl:variable name="p11vatWidth" select="if ($faWiersz/crd:P_11Vat) then 7 else 0"/>
-            <xsl:variable name="p11aWidth" select="if ($faWiersz/crd:P_11A) then 10 else 0"/>
-            <xsl:variable name="calculatedWidth" select="100 - $fixedWidth - $indeksWidth - $gtinWidth - $pkwiuWidth - $cnWidth - $pkobWidth - $kwotaAkcyzyWidth - $p6aWidth - $p9aWidth - $p9bWidth - $p10Width - $p12Width - $p11Width - $p11vatWidth - $p11aWidth"/>
-            <xsl:value-of select="concat($calculatedWidth, '%')"/>
-        </xsl:variable>
+        <!-- Table header -->
+        <fo:table table-layout="fixed"
+                  font-size="{$tableFontSize}pt"
+                  width="100%"
+                  border-collapse="separate"
+                  space-after="5mm">
+            <xsl:call-template name="tableHeader">
+                <xsl:with-param name="hasIndeks"      select="boolean($faWiersz/crd:Indeks)"/>
+                <xsl:with-param name="hasGTIN"        select="boolean($faWiersz/crd:GTIN)"/>
+                <xsl:with-param name="hasPKWiU"       select="boolean($faWiersz/crd:PKWiU)"/>
+                <xsl:with-param name="hasCN"          select="boolean($faWiersz/crd:CN)"/>
+                <xsl:with-param name="hasPKOB"        select="boolean($faWiersz/crd:PKOB)"/>
+                <xsl:with-param name="hasKwotaAkcyzy" select="boolean($faWiersz/crd:KwotaAkcyzy)"/>
+                <xsl:with-param name="hasP9A"         select="boolean($faWiersz/crd:P_9A)"/>
+                <xsl:with-param name="hasP9B"         select="boolean($faWiersz/crd:P_9B)"/>
+                <xsl:with-param name="hasP10"         select="boolean($faWiersz/crd:P_10)"/>
+                <xsl:with-param name="hasP12"         select="boolean($faWiersz/crd:P_12)"/>
+                <xsl:with-param name="hasP11"         select="boolean($faWiersz/crd:P_11)"/>
+                <xsl:with-param name="hasP11Vat"      select="boolean($faWiersz/crd:P_11Vat)"/>
+                <xsl:with-param name="hasP11A"        select="boolean($faWiersz/crd:P_11A)"/>
+                <xsl:with-param name="hasP6A"         select="boolean($faWiersz/crd:P_6A)"/>
+            </xsl:call-template>
 
-        <!-- Define the table structure -->
-        <fo:table table-layout="fixed" width="100%" border-collapse="separate" space-after="5mm">
-            <!-- Define table columns -->
-            <fo:table-column column-width="4%"/> <!-- Lp. -->
-            <xsl:if test="$faWiersz/crd:Indeks">
-                <fo:table-column column-width="8%"/> <!-- Indeks -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:GTIN">
-                <fo:table-column column-width="5%"/> <!-- GTIN -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:PKWiU">
-                <fo:table-column column-width="5%"/> <!-- PKWiU -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:CN">
-                <fo:table-column column-width="6%"/> <!-- CN -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:PKOB">
-                <fo:table-column column-width="6%"/> <!-- PKOB -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:KwotaAkcyzy">
-                <fo:table-column column-width="8%"/> <!-- Kwota akcyzy -->
-            </xsl:if>
-            <fo:table-column column-width="{$nameColumnWidth}"/> <!-- Nazwa - dynamiczna szerokość -->
-            <fo:table-column column-width="8%"/> <!-- Ilość -->
-            <fo:table-column column-width="5%"/> <!-- Jednostka -->
-            <xsl:if test="$faWiersz/crd:P_9A">
-                <fo:table-column column-width="10%"/> <!-- Cena jednostkowa netto -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_9B">
-                <fo:table-column column-width="10%"/> <!-- Cena jednostkowa brutto -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_10">
-                <fo:table-column column-width="7%"/> <!-- Rabat -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_12">
-                <fo:table-column column-width="8%"/> <!-- Stawka podatku -->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_11">
-                <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży netto-->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_11Vat">
-                <fo:table-column column-width="7%"/> <!-- Kwota VAT-->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_11A">
-                <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży brutto-->
-            </xsl:if>
-            <xsl:if test="$faWiersz/crd:P_6A">
-                <fo:table-column column-width="9%"/> <!-- Data dostawy (P_6A) -->
-            </xsl:if>
-
-            <!-- Table header -->
-            <fo:table-header>
-                <fo:table-row background-color="#f5f5f5" font-weight="bold">
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.lp', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <xsl:if test="$faWiersz/crd:Indeks">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.indeks', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:GTIN">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.gtin', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:PKWiU">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.pkwiu', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:CN">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.cn', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:PKOB">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.pkob', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:KwotaAkcyzy">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.exciseAmount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.productName', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.quantity', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.unit', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <xsl:if test="$faWiersz/crd:P_9A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceNet', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_9B">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceGross', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_10">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.discount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_12">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.taxRate', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_11">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.netValue', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_11Vat">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.vatAmount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_11A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.grossValue', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWiersz/crd:P_6A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.deliveryDate', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                </fo:table-row>
-            </fo:table-header>
-
-                    <!-- Table body -->
+        <!-- Table body -->
         <fo:table-body>
             <!-- Apply templates to each position; tunnel column visibility so row output matches this table's columns (correction before/after can differ) -->
             <xsl:apply-templates select="$faWiersz">
@@ -265,33 +303,29 @@
             </xsl:if>
             <xsl:if test="$showGTIN">
                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                    <xsl:variable name="gtinValue" select="string(crd:GTIN)"/>
-                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                        <xsl:value-of select="local:softWrap($gtinValue, 5)"/>
+                    <fo:block>
+                        <xsl:value-of select="crd:GTIN"/>
                     </fo:block>
                 </fo:table-cell>
             </xsl:if>
             <xsl:if test="$showPKWiU">
                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                    <xsl:variable name="pkwiuValue" select="string(crd:PKWiU)"/>
-                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                        <xsl:value-of select="local:softWrap($pkwiuValue, 6)"/>
+                    <fo:block>
+                        <xsl:value-of select="crd:PKWiU"/>
                     </fo:block>
                 </fo:table-cell>
             </xsl:if>
             <xsl:if test="$showCN">
                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                    <xsl:variable name="cnValue" select="string(crd:CN)"/>
-                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                        <xsl:value-of select="local:softWrap($cnValue, 6)"/> <!-- CN -->
+                    <fo:block>
+                        <xsl:value-of select="crd:CN"/>
                     </fo:block>
                 </fo:table-cell>
             </xsl:if>
             <xsl:if test="$showPKOB">
                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                    <xsl:variable name="pkobValue" select="string(crd:PKOB)"/>
-                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                        <xsl:value-of select="local:softWrap($pkobValue, 6)"/>
+                    <fo:block>
+                        <xsl:value-of select="crd:PKOB"/>
                     </fo:block>
                 </fo:table-cell>
             </xsl:if>
@@ -514,172 +548,41 @@
         <xsl:param name="faWierszAfter"/>
 
         <!-- Column visibility: show column if it appears in EITHER before OR after (union), so differing structures don't break the table -->
-        <xsl:variable name="diffShowIndeks" select="boolean($faWierszBefore/crd:Indeks or $faWierszAfter/crd:Indeks)"/>
-        <xsl:variable name="diffShowGTIN" select="boolean($faWierszBefore/crd:GTIN or $faWierszAfter/crd:GTIN)"/>
-        <xsl:variable name="diffShowPKWiU" select="boolean($faWierszBefore/crd:PKWiU or $faWierszAfter/crd:PKWiU)"/>
-        <xsl:variable name="diffShowCN" select="boolean($faWierszBefore/crd:CN or $faWierszAfter/crd:CN)"/>
-        <xsl:variable name="diffShowPKOB" select="boolean($faWierszBefore/crd:PKOB or $faWierszAfter/crd:PKOB)"/>
-        <xsl:variable name="diffShowKwotaAkcyzy" select="boolean($faWierszBefore/crd:KwotaAkcyzy or $faWierszAfter/crd:KwotaAkcyzy)"/>
-        <xsl:variable name="diffShowP6A" select="boolean($faWierszBefore/crd:P_6A or $faWierszAfter/crd:P_6A)"/>
-        <xsl:variable name="diffShowP9A" select="boolean($faWierszBefore/crd:P_9A or $faWierszAfter/crd:P_9A)"/>
-        <xsl:variable name="diffShowP9B" select="boolean($faWierszBefore/crd:P_9B or $faWierszAfter/crd:P_9B)"/>
-        <xsl:variable name="diffShowP10" select="boolean($faWierszBefore/crd:P_10 or $faWierszAfter/crd:P_10)"/>
-        <xsl:variable name="diffShowP11" select="boolean($faWierszBefore/crd:P_11 or $faWierszAfter/crd:P_11)"/>
-        <xsl:variable name="diffShowP11Vat" select="boolean($faWierszBefore/crd:P_11Vat or $faWierszAfter/crd:P_11Vat)"/>
-        <xsl:variable name="diffShowP11A" select="boolean($faWierszBefore/crd:P_11A or $faWierszAfter/crd:P_11A)"/>
+        <xsl:variable name="diffShowIndeks" select="$faWierszBefore/crd:Indeks or $faWierszAfter/crd:Indeks"/>
+        <xsl:variable name="diffShowGTIN" select="$faWierszBefore/crd:GTIN or $faWierszAfter/crd:GTIN"/>
+        <xsl:variable name="diffShowPKWiU" select="$faWierszBefore/crd:PKWiU or $faWierszAfter/crd:PKWiU"/>
+        <xsl:variable name="diffShowCN" select="$faWierszBefore/crd:CN or $faWierszAfter/crd:CN"/>
+        <xsl:variable name="diffShowPKOB" select="$faWierszBefore/crd:PKOB or $faWierszAfter/crd:PKOB"/>
+        <xsl:variable name="diffShowKwotaAkcyzy" select="$faWierszBefore/crd:KwotaAkcyzy or $faWierszAfter/crd:KwotaAkcyzy"/>
+        <xsl:variable name="diffShowP6A" select="$faWierszBefore/crd:P_6A or $faWierszAfter/crd:P_6A"/>
+        <xsl:variable name="diffShowP9A" select="$faWierszBefore/crd:P_9A or $faWierszAfter/crd:P_9A"/>
+        <xsl:variable name="diffShowP9B" select="$faWierszBefore/crd:P_9B or $faWierszAfter/crd:P_9B"/>
+        <xsl:variable name="diffShowP10" select="$faWierszBefore/crd:P_10 or $faWierszAfter/crd:P_10"/>
+        <xsl:variable name="diffShowP11" select="$faWierszBefore/crd:P_11 or $faWierszAfter/crd:P_11"/>
+        <xsl:variable name="diffShowP11Vat" select="$faWierszBefore/crd:P_11Vat or $faWierszAfter/crd:P_11Vat"/>
+        <xsl:variable name="diffShowP11A" select="$faWierszBefore/crd:P_11A or $faWierszAfter/crd:P_11A"/>
 
-        <!-- Calculate column width for name based on union of optional columns -->
-        <xsl:variable name="nameColumnWidth">
-            <xsl:variable name="fixedWidth" select="17"/>
-            <xsl:variable name="indeksWidth" select="if ($diffShowIndeks) then 8 else 0"/>
-            <xsl:variable name="gtinWidth" select="if ($diffShowGTIN) then 5 else 0"/>
-            <xsl:variable name="pkwiuWidth" select="if ($diffShowPKWiU) then 5 else 0"/>
-            <xsl:variable name="cnWidth" select="if ($diffShowCN) then 6 else 0"/>
-            <xsl:variable name="pkobWidth" select="if ($diffShowPKOB) then 6 else 0"/>
-            <xsl:variable name="kwotaAkcyzyWidth" select="if ($diffShowKwotaAkcyzy) then 8 else 0"/>
-            <xsl:variable name="p6aWidth" select="if ($diffShowP6A) then 9 else 0"/>
-            <xsl:variable name="p9aWidth" select="if ($diffShowP9A) then 10 else 0"/>
-            <xsl:variable name="p9bWidth" select="if ($diffShowP9B) then 10 else 0"/>
-            <xsl:variable name="p10Width" select="if ($diffShowP10) then 7 else 0"/>
-            <xsl:variable name="p12Width" select="8"/>
-            <xsl:variable name="p11Width" select="if ($diffShowP11) then 10 else 0"/>
-            <xsl:variable name="p11vatWidth" select="if ($diffShowP11Vat) then 7 else 0"/>
-            <xsl:variable name="p11aWidth" select="if ($diffShowP11A) then 10 else 0"/>
-            <xsl:variable name="calculatedWidth" select="100 - $fixedWidth - $indeksWidth - $gtinWidth - $pkwiuWidth - $cnWidth - $pkobWidth - $kwotaAkcyzyWidth - $p6aWidth - $p9aWidth - $p9bWidth - $p10Width - $p12Width - $p11Width - $p11vatWidth - $p11aWidth"/>
-            <xsl:value-of select="concat($calculatedWidth, '%')"/>
-        </xsl:variable>
-
-        <fo:table table-layout="fixed" width="100%" border-collapse="separate" space-after="5mm">
-            <fo:table-column column-width="4%"/> <!-- Lp. -->
-            <xsl:if test="$diffShowIndeks">
-                <fo:table-column column-width="8%"/> <!-- Indeks -->
-            </xsl:if>
-            <xsl:if test="$diffShowGTIN">
-                <fo:table-column column-width="5%"/> <!-- GTIN -->
-            </xsl:if>
-            <xsl:if test="$diffShowPKWiU">
-                <fo:table-column column-width="5%"/> <!-- PKWiU -->
-            </xsl:if>
-            <xsl:if test="$diffShowCN">
-                <fo:table-column column-width="6%"/> <!-- CN -->
-            </xsl:if>
-            <xsl:if test="$diffShowPKOB">
-                <fo:table-column column-width="6%"/> <!-- PKOB -->
-            </xsl:if>
-            <xsl:if test="$diffShowKwotaAkcyzy">
-                <fo:table-column column-width="8%"/> <!-- Kwota akcyzy -->
-            </xsl:if>
-            <fo:table-column column-width="{$nameColumnWidth}"/> <!-- Nazwa -->
-            <fo:table-column column-width="8%"/> <!-- Ilość -->
-            <fo:table-column column-width="5%"/> <!-- Jednostka -->
-            <xsl:if test="$diffShowP9A">
-                <fo:table-column column-width="10%"/> <!-- Cena jednostkowa netto -->
-            </xsl:if>
-            <xsl:if test="$diffShowP9B">
-                <fo:table-column column-width="10%"/> <!-- Cena jednostkowa brutto -->
-            </xsl:if>
-            <xsl:if test="$diffShowP10">
-                <fo:table-column column-width="7%"/> <!-- Rabat -->
-            </xsl:if>
-            <fo:table-column column-width="8%"/> <!-- Stawka podatku -->
-            <xsl:if test="$diffShowP11">
-                <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży netto-->
-            </xsl:if>
-            <xsl:if test="$diffShowP11Vat">
-                <fo:table-column column-width="7%"/> <!-- Kwota VAT-->
-            </xsl:if>
-            <xsl:if test="$diffShowP11A">
-                <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży brutto-->
-            </xsl:if>
-            <xsl:if test="$diffShowP6A">
-                <fo:table-column column-width="9%"/> <!-- Data dostawy (P_6A) -->
-            </xsl:if>
-
-            <!-- Table header -->
-            <fo:table-header>
-                <fo:table-row background-color="#f5f5f5" font-weight="bold">
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.lp', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <xsl:if test="$diffShowIndeks">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.indeks', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowGTIN">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.gtin', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowPKWiU">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.pkwiu', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowCN">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.cn', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowPKOB">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.pkob', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowKwotaAkcyzy">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.exciseAmount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.productName', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.quantity', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.unit', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <xsl:if test="$diffShowP9A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceNet', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowP9B">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceGross', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowP10">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.discount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                        <fo:block><xsl:value-of select="key('kLabels', 'row.taxRate', $labels)"/></fo:block>
-                    </fo:table-cell>
-                    <xsl:if test="$diffShowP11">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.netValue', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowP11Vat">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.vatAmount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowP11A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.grossValue', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$diffShowP6A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.deliveryDate', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                </fo:table-row>
-            </fo:table-header>
+        <fo:table table-layout="fixed"
+                  font-size="{$tableFontSize}pt"
+                  width="100%"
+                  border-collapse="separate"
+                  space-after="5mm">
+            <xsl:call-template name="tableHeader">
+                <xsl:with-param name="hasIndeks" select="$diffShowIndeks"/>
+                <xsl:with-param name="hasGTIN" select="$diffShowGTIN"/>
+                <xsl:with-param name="hasPKWiU" select="$diffShowPKWiU"/>
+                <xsl:with-param name="hasCN" select="$diffShowCN"/>
+                <xsl:with-param name="hasPKOB" select="$diffShowPKOB"/>
+                <xsl:with-param name="hasKwotaAkcyzy" select="$diffShowKwotaAkcyzy"/>
+                <xsl:with-param name="hasP9A" select="$diffShowP9A"/>
+                <xsl:with-param name="hasP9B" select="$diffShowP9B"/>
+                <xsl:with-param name="hasP10" select="$diffShowP10"/>
+                <xsl:with-param name="hasP12" select="true()"/>
+                <xsl:with-param name="hasP11" select="$diffShowP11"/>
+                <xsl:with-param name="hasP11Vat" select="$diffShowP11Vat"/>
+                <xsl:with-param name="hasP11A" select="$diffShowP11A"/>
+                <xsl:with-param name="hasP6A" select="$diffShowP6A"/>
+            </xsl:call-template>
 
             <!-- Table body -->
             <fo:table-body>
@@ -714,33 +617,29 @@
                             </xsl:if>
                             <xsl:if test="$diffShowGTIN">
                                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
-                                    <xsl:variable name="gtinValue" select="string($after/crd:GTIN)"/>
-                                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                                        <xsl:value-of select="local:softWrap($gtinValue, 5)"/>
+                                    <fo:block>
+                                        <xsl:value-of select="$after/crd:GTIN"/>
                                     </fo:block>
                                 </fo:table-cell>
                             </xsl:if>
                             <xsl:if test="$diffShowPKWiU">
                                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
-                                    <xsl:variable name="pkwiuValue" select="string($after/crd:PKWiU)"/>
-                                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                                        <xsl:value-of select="local:softWrap($pkwiuValue, 6)"/>
+                                    <fo:block>
+                                        <xsl:value-of select="$after/crd:PKWiU"/>
                                     </fo:block>
                                 </fo:table-cell>
                             </xsl:if>
                             <xsl:if test="$diffShowCN">
                                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
-                                    <xsl:variable name="cnValue" select="string($after/crd:CN)"/>
-                                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                                        <xsl:value-of select="local:softWrap($cnValue, 6)"/>
+                                    <fo:block>
+                                        <xsl:value-of select="$after/crd:CN"/>
                                     </fo:block>
                                 </fo:table-cell>
                             </xsl:if>
                             <xsl:if test="$diffShowPKOB">
                                 <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
-                                    <xsl:variable name="pkobValue" select="string($after/crd:PKOB)"/>
-                                    <fo:block font-size="6pt" wrap-option="wrap" white-space-collapse="false" linefeed-treatment="preserve">
-                                        <xsl:value-of select="local:softWrap($pkobValue, 6)"/>
+                                    <fo:block>
+                                        <xsl:value-of select="$after/crd:PKOB"/>
                                     </fo:block>
                                 </fo:table-cell>
                             </xsl:if>

--- a/src/test/java/io/alapierre/ksef/fop/AbstractGeneratePdfTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/AbstractGeneratePdfTest.java
@@ -38,7 +38,7 @@ class AbstractGeneratePdfTest {
         }
     }
 
-    private byte[] generateFa3InvoicePdf(String invoiceResource) throws Exception {
+    byte[] generateFa3InvoicePdf(String invoiceResource) throws Exception {
         PdfGenerator generator = new PdfGenerator(getFopConfig());
 
         InvoiceGenerationParams invoiceGenerationParams = InvoiceGenerationParams.builder()
@@ -50,22 +50,23 @@ class AbstractGeneratePdfTest {
             assertNotNull(inputStream);
 
             generator.generateInvoice(IOUtils.toByteArray(inputStream), invoiceGenerationParams, outputStream);
-            return writeDebugData(outputStream.toByteArray(), invoiceResource);
+            return outputStream.toByteArray();
         }
     }
 
-    private byte[] writeDebugData(byte[] pdfData, String resourceName) throws IOException {
-        if (DEBUG) {
-            Path destDir = Paths.get("target/test-output");
-            Path destFile = destDir.resolve(resourceName + ".pdf");
-            Files.createDirectories(destFile.getParent());
-            Files.write(destFile, pdfData);
-        }
-        return pdfData;
+    void writeDebugData(byte[] pdfData, String resourceName) throws IOException {
+        Path destDir = Paths.get("target/test-output");
+        Path destFile = destDir.resolve(resourceName + ".pdf");
+        Files.createDirectories(destFile.getParent());
+        Files.write(destFile, pdfData);
     }
 
     String generateFa3InvoiceText(String invoiceResource) throws Exception {
-        return extractTextFromPdf(generateFa3InvoicePdf(invoiceResource));
+        byte[] pdfData = generateFa3InvoicePdf(invoiceResource);
+        if (DEBUG) {
+            writeDebugData(pdfData, invoiceResource);
+        }
+        return extractTextFromPdf(pdfData);
     }
 
     static String textResource(String resource) throws IOException {

--- a/src/test/java/io/alapierre/ksef/fop/ColumnSizeTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/ColumnSizeTest.java
@@ -1,0 +1,27 @@
+package io.alapierre.ksef.fop;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Visual tests for invoice row column sizing.
+ *
+ * <p><strong>Warning:</strong> These tests don't have assertions and need to be checked manually to see if the output
+ * in {@code target/test-output/faktury/ColumnSizeTest} looks OK.
+ */
+class ColumnSizeTest extends AbstractGeneratePdfTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"GTIN", "PKWiU", "CN", "PKOB"})
+    void columnFitsContent(String column) throws Exception {
+        byte[] pdfData = generateFa3InvoicePdf("faktury/ColumnSizeTest/" + column + ".xml");
+        writeDebugData(pdfData, "faktury/ColumnSizeTest/" + column);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"GTIN", "PKWiU", "CN", "PKOB"})
+    void diffColumnFitsContent(String column) throws Exception {
+        byte[] pdfData = generateFa3InvoicePdf("faktury/ColumnSizeTest/diff_" + column + ".xml");
+        writeDebugData(pdfData, "faktury/ColumnSizeTest/diff_" + column);
+    }
+}

--- a/src/test/resources/faktury/ColumnSizeTest/CN.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/CN.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/1/02/2026</P_2>
+        <P_15>100.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>VAT</RodzajFaktury>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <CN>1234 5678</CN>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/GTIN.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/GTIN.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/1/02/2026</P_2>
+        <P_15>100.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>VAT</RodzajFaktury>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <GTIN>1234567890123</GTIN>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/PKOB.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/PKOB.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/1/02/2026</P_2>
+        <P_15>100.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>VAT</RodzajFaktury>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <PKOB>1234</PKOB>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/PKWiU.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/PKWiU.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/1/02/2026</P_2>
+        <P_15>100.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>VAT</RodzajFaktury>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <PKWiU>12.34.56.7</PKWiU>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/diff_CN.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/diff_CN.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/KOR/1/02/2026</P_2>
+        <P_15>0.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>KOR</RodzajFaktury>
+
+        <DaneFaKorygowanej>
+            <DataWystFaKorygowanej>2026-01-01</DataWystFaKorygowanej>
+            <NrFaKorygowanej>FV/1/01/2026</NrFaKorygowanej>
+        </DaneFaKorygowanej>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <CN>1234 5678</CN>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+            <StanPrzed>1</StanPrzed>
+        </FaWiersz>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <CN>8765 4321</CN>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>200.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/diff_GTIN.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/diff_GTIN.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/KOR/1/02/2026</P_2>
+        <P_15>0.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>KOR</RodzajFaktury>
+
+        <DaneFaKorygowanej>
+            <DataWystFaKorygowanej>2026-01-01</DataWystFaKorygowanej>
+            <NrFaKorygowanej>FV/1/01/2026</NrFaKorygowanej>
+        </DaneFaKorygowanej>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <GTIN>1234567890123</GTIN>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+            <StanPrzed>1</StanPrzed>
+        </FaWiersz>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <GTIN>3210987654321</GTIN>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>200.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/diff_PKOB.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/diff_PKOB.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/KOR/1/02/2026</P_2>
+        <P_15>0.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>KOR</RodzajFaktury>
+
+        <DaneFaKorygowanej>
+            <DataWystFaKorygowanej>2026-01-01</DataWystFaKorygowanej>
+            <NrFaKorygowanej>FV/1/01/2026</NrFaKorygowanej>
+        </DaneFaKorygowanej>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <PKOB>1234</PKOB>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+            <StanPrzed>1</StanPrzed>
+        </FaWiersz>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <PKOB>4321</PKOB>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>200.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>

--- a/src/test/resources/faktury/ColumnSizeTest/diff_PKWiU.xml
+++ b/src/test/resources/faktury/ColumnSizeTest/diff_PKWiU.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/KOR/1/02/2026</P_2>
+        <P_15>0.00</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie><P_19N>1</P_19N></Zwolnienie>
+            <NoweSrodkiTransportu><P_22N>1</P_22N></NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy><P_PMarzyN>1</P_PMarzyN></PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>KOR</RodzajFaktury>
+
+        <DaneFaKorygowanej>
+            <DataWystFaKorygowanej>2026-01-01</DataWystFaKorygowanej>
+            <NrFaKorygowanej>FV/1/01/2026</NrFaKorygowanej>
+        </DaneFaKorygowanej>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <PKWiU>12.34.56.7</PKWiU>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>1</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>100.00</P_11>
+            <P_12>23</P_12>
+            <StanPrzed>1</StanPrzed>
+        </FaWiersz>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <PKWiU>76.54.32.1</PKWiU>
+            <P_7>Towar testowy</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>2</P_8B>
+            <P_9A>100.00</P_9A>
+            <P_11>200.00</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>


### PR DESCRIPTION
Corrects column widths for CN, PKOB, GTIN and PKWiU fields:

- Switches from percentage-based to `em`-based widths, which scale automatically with font size and simplify future adjustments.
- Sizes each column to its realistic maximum content width, using 0.6em per digit and 0.3em per dot or space (conservative estimates for the OpenSans font).

Additional refactoring:

- Replaces the ad-hoc remaining-space computation with `proportional-column-width(1)`.
- Extracts column definitions and table header into a shared template reused by both `positionsTable` and `differencesTable`.

### Testing

Adds a visual test for column widths. Overflow must be checked manually, as Apache FOP does not support `overflow="error-if-overflow"`.

Fixes #74
