### PR TITLE
Run Sonar scan on PR head not base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # 5.0.2

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
         with:
+          # The default reference for `workflow_run` is the base branch of a PR, not the PR head.
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Download coverage, test results and binary artifacts


### PR DESCRIPTION
My previous comment in https://github.com/ksef4dev/ksef-fop/pull/47#discussion_r2720948286 was wrong: apparently a `workflow_run`-triggered action points to the base of the PR and not the head branch.

This change ensures that both `build` and `sonar` run on the same source code.
