### PR TITLE
Update `SECURITY.md`

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,39 @@
 
 ## Supported Versions
 
+Only the latest release of `ksef-fop` receives security fixes.
 
 | Version | Supported          |
-|---------|--------------------|
-| 1.0.x   | :white_check_mark: |
-
+| ------- |--------------------|
+| latest  | :heavy_check_mark: |
+| older   | :x:                |
 
 ## Reporting a Vulnerability
 
-If you found new security vulnerability, please create new issue with CVE or NVD numberor other usfull informaton. 
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+All vulnerabilities must be disclosed privately using
+**[GitHub Private Security Reporting](https://github.com/ksef4dev/ksef-fop/security/advisories/new)**.
+
+This ensures that:
+- The maintainers are notified immediately and can coordinate a fix before public disclosure.
+- A CVE identifier is requested from and issued by **GitHub** in its role as a
+  [CVE Numbering Authority (CNA)](https://www.cve.org/ProgramOrganization/CNAs).
+- The advisory and any assigned CVE are published only after a patch is available.
+
+### Steps
+
+1. Navigate to the [Security Advisories](https://github.com/ksef4dev/ksef-fop/security/advisories/new) page and open a new draft advisory.
+2. Provide a clear description of the vulnerability, affected versions, and reproduction steps.
+3. The maintainers will assess your report and work with you on a coordinated disclosure timeline.
+4. Once a fix is ready, the advisory will be published and a CVE will be requested from GitHub CNA.
+
+## CVE Policy
+
+CVEs for vulnerabilities in this project are issued exclusively through the GitHub CNA via the
+GitHub Security Advisory process described above.
+
+If you are a security researcher or another CNA considering assigning a CVE to this project,
+please **contact the maintainers first** through the private reporting channel above.
+Uncoordinated CVE assignments may result in incomplete or inaccurate vulnerability records
+and prevent the maintainers from shipping a fix alongside disclosure.


### PR DESCRIPTION
Updates `SECURITY.md` with the project's vulnerability disclosure policy. The file:

- Defines GitHub Private Security Reporting as the sole intake channel for vulnerability reports.
- Requests that CVEs be issued exclusively through the GitHub CNA via the GitHub Security Advisory process.
- Warns researchers and other CNAs against uncoordinated disclosure, given that the project falls within the broad scope of multiple CNAs.

The purpose of the update is to guide researchers in the reporting process and prevent CNAs from assigning CVEs without the project's consent.
