### PR TITLE
fix: handle negative P_13_11 margin in ksef_invoice tax summary

### DIFF
--- a/src/main/resources/templates/fa3/ksef_invoice.xsl
+++ b/src/main/resources/templates/fa3/ksef_invoice.xsl
@@ -1728,7 +1728,7 @@
                                         </xsl:if>
                                     </fo:table-row>
                                 </xsl:if>
-                                <xsl:if test="crd:Fa/crd:P_13_11 and crd:Fa/crd:P_13_11 > 0">
+                                <xsl:if test="crd:Fa/crd:P_13_11 and crd:Fa/crd:P_13_11 != 0">
                                     <fo:table-row>
                                         <fo:table-cell
                                                 xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">


### PR DESCRIPTION
Mirror the fix. 
The margin (P_13_11) row in the tax summary of `ksef_invoice.xsl` is guarded by `P_13_11 > 0`, which  skips correction invoices that carry a negative margin.
Relaxes the guard to `!= 0` so the row renders for both positive and negative amounts
