### PR TITLE
refactor template loading for local-path custom XSLT

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,22 +111,25 @@ By default the library picks a built-in XSL-FO template based on the `InvoiceSch
 (`FA2_1_0_E` → `templates/fa2/ksef_invoice.xsl`, `FA3_1_0_E` → `templates/fa3/ksef_invoice.xsl`).
 If you need full control over the PDF layout you can provide your own XSL-FO stylesheet instead.
 
-Set `templatePath` on `InvoiceGenerationParams` to a **classpath-relative** path pointing to
+Set `templatePath` on `InvoiceGenerationParams` to a local file path pointing to
 your custom XSL file:
 
 ````java
 InvoiceGenerationParams params = InvoiceGenerationParams.builder()
         .schema(InvoiceSchema.FA3_1_0_E)
         .ksefNumber("1234567890-20231221-XXXXXXXX-XX")
-        .templatePath("templates/custom/my_invoice.xsl")
+        .templatePath("/opt/my-app/templates/my_invoice.xsl")
         .build();
 ````
 
-When `templatePath` is set the library uses it directly; when it is `null` (the default) the
-template is resolved automatically from the schema.
+When `templatePath` is set and points to an existing local file, that file is used directly.
+When it is `null` (the default), the template is resolved automatically from the schema and
+loaded from classpath.
 
-> **Security note:** `templatePath` is used as-is to load a classpath resource. Make sure
-> untrusted users cannot control this value or the underlying XSL content.
+When `templatePath` is set, it must point to an existing local file.
+
+> **Security note:** XSLT is executable content. Make sure untrusted users cannot control
+> `templatePath` or the underlying XSL file/resource.
 
 ## Custom properties
 
@@ -142,7 +145,7 @@ template can declare and use it like any other parameter.
 InvoiceGenerationParams params = InvoiceGenerationParams.builder()
         .schema(InvoiceSchema.FA3_1_0_E)
         .ksefNumber("1234567890-20231221-XXXXXXXX-XX")
-        .templatePath("templates/custom/my_invoice.xsl")
+        .templatePath("/opt/my-app/templates/my_invoice.xsl")
         .customProperties(Map.of(
                 "companySlogan", "We deliver on time!",
                 "showWatermark", true

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -45,11 +45,13 @@ public class InvoiceGenerationParams {
     private InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest;
 
     /**
-     * Optional classpath-relative path to a custom XSLT invoice template.
+     * Optional path to a custom XSLT invoice template.
      * <p>
-     * Security note: This value must reference a trusted stylesheet available on the application's classpath.
-     * The library does not validate where this path comes from; callers are responsible for ensuring that
-     * untrusted users cannot control this value or the underlying XSLT content.
+     * <ul>
+     *     <li>If this value is {@code null} or blank, the default built-in template is loaded from classpath based on schema.</li>
+     *     <li>If this value is provided, it must point to an existing local file and that file is used as the custom template.</li>
+     * </ul>
+     * Security note: XSLT is executable content. Make sure untrusted users cannot control this value or the underlying XSLT file.
      */
     @Nullable
     private String templatePath;

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -20,6 +20,9 @@ import javax.xml.transform.*;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.net.URI;
 import java.net.URL;
 import java.time.LocalDate;
@@ -174,11 +177,9 @@ public class PdfGenerator {
 
         TransformerFactory factory = new TransformerFactoryImpl();
         factory.setURIResolver(new ClasspathUriResolver());
-        String xslPath = resolveTemplatePath(params);
-
-        URL xslUrl = getResourceUrl(xslPath);
-        try (InputStream xsl = loadResource(xslPath)) {
-            Transformer transformer = factory.newTransformer(new StreamSource(xsl, xslUrl.toExternalForm()));
+        StreamSource templateSource = resolveInvoiceTemplateSource(params);
+        try (InputStream xsl = templateSource.getInputStream()) {
+            Transformer transformer = factory.newTransformer(new StreamSource(xsl, templateSource.getSystemId()));
             applyParameters(params, qrCodes, duplicateDate, transformer);
 
             Source xmlSource = new StreamSource(new ByteArrayInputStream(invoiceXml));
@@ -187,12 +188,20 @@ public class PdfGenerator {
         }
     }
 
-    private @NotNull String resolveTemplatePath(InvoiceGenerationParams params) {
+    private @NotNull StreamSource resolveInvoiceTemplateSource(InvoiceGenerationParams params) throws IOException {
         String templatePath = params.getTemplatePath();
 
-        return (templatePath != null && !templatePath.isEmpty())
-                ? templatePath
-                : resolveXslTemplate(params);
+        if (templatePath == null || templatePath.isEmpty()) {
+            String defaultTemplate = resolveXslTemplate(params);
+            URL xslUrl = getResourceUrl(defaultTemplate);
+            return new StreamSource(loadResource(defaultTemplate), xslUrl.toExternalForm());
+        }
+
+        Path candidatePath = Paths.get(templatePath);
+        if (!Files.isRegularFile(candidatePath)) {
+            throw new IOException("Template path does not point to an existing local file: " + candidatePath);
+        }
+        return new StreamSource(Files.newInputStream(candidatePath), candidatePath.toUri().toString());
     }
 
     private static @NotNull String getUpoTemplatePathForSchema(UpoGenerationParams params) {

--- a/src/test/java/io/alapierre/ksef/fop/CustomTemplateOverrideTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/CustomTemplateOverrideTest.java
@@ -9,8 +9,12 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,11 +39,12 @@ class CustomTemplateOverrideTest {
             try (InputStream invoiceIs = getResourceAsStream("faktury/fa3/podstawowa/FA_3_Przyklad_1.xml")) {
                 assertNotNull(invoiceIs);
                 byte[] invoiceXml = IOUtils.toByteArray(invoiceIs);
+                Path customTemplate = createCustomTemplateFile();
 
                 InvoiceGenerationParams params = InvoiceGenerationParams.builder()
                         .schema(InvoiceSchema.FA3_1_0_E)
                         .ksefNumber("TEST-KSEF-NUMBER")
-                        .templatePath("templates/custom/custom_invoice.xsl")
+                        .templatePath(customTemplate.toString())
                         .customProperties(Collections.singletonMap("customPropertyDemo", "HELLO-CUSTOM-PROPERTY"))
                         .build();
 
@@ -51,6 +56,39 @@ class CustomTemplateOverrideTest {
                 assertTrue(text.contains("nrKsef=TEST-KSEF-NUMBER"), "Expected nrKsef parameter rendered by custom template");
                 assertTrue(text.contains("customPropertyDemo=HELLO-CUSTOM-PROPERTY"), "Expected custom property rendered by custom template");
             }
+        }
+    }
+
+    @Test
+    void generateInvoice_failsWhenTemplatePathIsNotAnExistingLocalFile() throws Exception {
+        try (InputStream fopCfg = getResourceAsStream("fop.xconf")) {
+            assertNotNull(fopCfg);
+            PdfGenerator generator = new PdfGenerator(fopCfg);
+
+            try (InputStream invoiceIs = getResourceAsStream("faktury/fa3/podstawowa/FA_3_Przyklad_1.xml")) {
+                assertNotNull(invoiceIs);
+                byte[] invoiceXml = IOUtils.toByteArray(invoiceIs);
+
+                InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                        .schema(InvoiceSchema.FA3_1_0_E)
+                        .ksefNumber("TEST-KSEF-NUMBER")
+                        .templatePath("templates/custom/custom_invoice.xsl")
+                        .build();
+
+                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                IOException ex = assertThrows(IOException.class, () -> generator.generateInvoice(invoiceXml, params, out));
+                assertTrue(ex.getMessage().contains("existing local file"));
+            }
+        }
+    }
+
+    private Path createCustomTemplateFile() throws IOException {
+        try (InputStream customTemplate = getResourceAsStream("templates/custom/custom_invoice.xsl")) {
+            assertNotNull(customTemplate);
+            Path tempFile = Files.createTempFile("ksef-custom-template-", ".xsl");
+            Files.copy(customTemplate, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            tempFile.toFile().deleteOnExit();
+            return tempFile;
         }
     }
 }


### PR DESCRIPTION
## Summary

- allow custom invoice template override via explicit local file path passed in `templatePath`
- keep built-in default templates resolved from classpath when `templatePath` is empty

## Additional Changes

- update docs/Javadocs to describe expected `templatePath` behavior