### PR TITLE
Add TemplateResolver with filesystem roots and classpath fallback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.xmlresolver</groupId>
+            <artifactId>xmlresolver</artifactId>
+            <version>5.2.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>core</artifactId>
             <version>${zxing.version}</version>

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -1,21 +1,28 @@
 package io.alapierre.ksef.fop;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Singular;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Data
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class InvoiceGenerationParams {
     @Nullable
     private String verificationLink;
@@ -66,4 +73,52 @@ public class InvoiceGenerationParams {
 
     @Builder.Default
     private Language language = Language.PL;
+
+    /**
+     * Ordered list of filesystem directories searched before the classpath when resolving templates.
+     */
+    @Singular("templateRoot")
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private List<Path> templateRoots;
+
+    /**
+     * @deprecated use the builder instead.
+     */
+    @Deprecated
+    public InvoiceGenerationParams(
+            @Nullable String verificationLink,
+            byte[] logo,
+            URI logoUri,
+            @Nullable LocalDate currencyDate,
+            @Nullable String issuerUser,
+            boolean showCorrectionDifferences,
+            @NotNull InvoiceSchema schema,
+            @Nullable String ksefNumber,
+            @Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest,
+            @Nullable String templatePath,
+            Map<String, Object> customProperties,
+            Language language) {
+        this.verificationLink = verificationLink;
+        this.logo = logo;
+        this.logoUri = logoUri;
+        this.currencyDate = currencyDate;
+        this.issuerUser = issuerUser;
+        this.showCorrectionDifferences = showCorrectionDifferences;
+        this.schema = schema;
+        this.ksefNumber = ksefNumber;
+        this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
+        this.templatePath = templatePath;
+        this.customProperties = customProperties != null ? customProperties : new HashMap<>();
+        this.language = language != null ? language : Language.PL;
+        this.templateRoots = Collections.emptyList();
+    }
+
+    /**
+     * Returns an unmodifiable view of the configured filesystem template roots.
+     */
+    public List<Path> getTemplateRoots() {
+        if (templateRoots == null) return Collections.emptyList();
+        return Collections.unmodifiableList(templateRoots);
+    }
 }

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -1,10 +1,11 @@
 package io.alapierre.ksef.fop;
 
 import io.alapierre.ksef.fop.i18n.TranslationService;
+import io.alapierre.ksef.fop.internal.Strings;
+import io.alapierre.ksef.fop.internal.TemplateResolver;
 import io.alapierre.ksef.fop.qr.QrCodeBuilder;
 import io.alapierre.ksef.fop.qr.QrCodeData;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 import net.sf.saxon.TransformerFactoryImpl;
 import org.apache.fop.apps.*;
 import org.apache.fop.apps.io.InternalResourceResolver;
@@ -16,12 +17,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.w3c.dom.Document;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.*;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.net.URI;
-import java.net.URL;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -103,12 +105,9 @@ public class PdfGenerator {
     public void generateUpo(Source upoXML, UpoGenerationParams params, OutputStream out) throws IOException, TransformerException, FOPException {
         FopFactory fopFactory = createFopFactory();
         FOUserAgent foUserAgent = fopFactory.newFOUserAgent();
+        Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
-        Fop fop = fopFactory.newFop("application/pdf", foUserAgent, out);
-        TransformerFactory factory = TransformerFactory.newInstance();
-
-        String templatePath = getUpoTemplatePathForSchema(params);
-        Transformer transformer = factory.newTransformer(new StreamSource(loadResource(templatePath)));
+        Transformer transformer = createTransformer(params.getTemplateRoots(), resolveUpoTemplatePath(params));
 
         try {
             Document labels = translationService.getTranslationsAsXml(params.getLanguage().getCode());
@@ -185,46 +184,53 @@ public class PdfGenerator {
         FOUserAgent foUserAgent = fopFactory.newFOUserAgent();
         Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
+        Transformer transformer = createTransformer(params.getTemplateRoots(), resolveTemplatePath(params));
+
+        applyParameters(params, qrCodes, duplicateDate, transformer);
+
+        Source xmlSource = new StreamSource(new ByteArrayInputStream(invoiceXml));
+        Result result = new SAXResult(fop.getDefaultHandler());
+        transformer.transform(xmlSource, result);
+    }
+
+    private static Transformer createTransformer(List<Path> roots, String systemId) throws TransformerException {
+        TemplateResolver resolver = new TemplateResolver(roots);
+        return createTransformerFactory(resolver).newTransformer(resolver.resolve(systemId, null));
+    }
+
+    private static TransformerFactory createTransformerFactory(TemplateResolver resolver) throws TransformerException {
         TransformerFactory factory = new TransformerFactoryImpl();
-        factory.setURIResolver(new ClasspathUriResolver());
-        String xslPath = resolveTemplatePath(params);
-
-        URL xslUrl = getResourceUrl(xslPath);
-        try (InputStream xsl = loadResource(xslPath)) {
-            Transformer transformer = factory.newTransformer(new StreamSource(xsl, xslUrl.toExternalForm()));
-            applyParameters(params, qrCodes, duplicateDate, transformer);
-
-            Source xmlSource = new StreamSource(new ByteArrayInputStream(invoiceXml));
-            Result result = new SAXResult(fop.getDefaultHandler());
-            transformer.transform(xmlSource, result);
-        }
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setURIResolver(resolver);
+        return factory;
     }
 
     private @NotNull String resolveTemplatePath(InvoiceGenerationParams params) {
         String templatePath = params.getTemplatePath();
+        return Strings.isEmpty(templatePath)
+                ? resolveXslTemplate(params)
+                : templatePath;
+    }
 
-        return (templatePath != null && !templatePath.isEmpty())
-                ? templatePath
-                : resolveXslTemplate(params);
+    private static @NotNull String resolveUpoTemplatePath(UpoGenerationParams params) {
+        String templatePath = params.getTemplatePath();
+        return Strings.isEmpty(templatePath)
+                ? getUpoTemplatePathForSchema(params)
+                : templatePath;
     }
 
     private static @NotNull String getUpoTemplatePathForSchema(UpoGenerationParams params) {
-        String templateFileName;
         switch (params.getSchema()) {
             case UPO_V3:
-                templateFileName = "templates/upo_v3/ksef_upo.fop";
-                break;
+                return "templates/upo_v3/ksef_upo.fop";
             case UPO_V4_2:
-                templateFileName = "templates/upo_v4/ksef_upo_v4_2.fop";
-                break;
+                return "templates/upo_v4/ksef_upo_v4_2.fop";
             case UPO_V4_3:
-                templateFileName = "templates/upo_v4/ksef_upo_v4_3.fop";
-                break;
+                return "templates/upo_v4/ksef_upo_v4_3.fop";
             default:
                 log.warn("UPO Schema is not provided in UpoGenerationParams or not supported, using default v3");
-                templateFileName = "templates/upo_v3/ksef_upo.fop";
+                return "templates/upo_v3/ksef_upo.fop";
         }
-        return templateFileName;
     }
 
     private void applyParameters(InvoiceGenerationParams params,
@@ -256,7 +262,6 @@ public class PdfGenerator {
             setParam(transformer, "currencyDate", params.getCurrencyDate().format(DateTimeFormatter.ISO_LOCAL_DATE));
         }
 
-        // proste flagi/teksty
         setParam(transformer, "nrKsef", params.getKsefNumber());
         setParam(transformer, "showFooter", invoicePdfConfig.isShowFooter());
         setParam(transformer, "useExtendedDecimalPlaces", invoicePdfConfig.isUseExtendedPriceDecimalPlaces());
@@ -302,15 +307,9 @@ public class PdfGenerator {
     }
 
     private static InputStream loadResource(String resource) throws IOException {
-        val res = PdfGenerator.class.getClassLoader().getResourceAsStream(resource);
+        InputStream res = PdfGenerator.class.getClassLoader().getResourceAsStream(resource);
         if (res == null) throw new IOException("Can't load classpath resource " + resource);
         return res;
-    }
-
-    private URL getResourceUrl(String resource) throws IOException {
-        URL url = getClass().getClassLoader().getResource(resource);
-        if (url == null) throw new IOException("Can't resolve classpath resource URL " + resource);
-        return url;
     }
 
     private static String resolveXslTemplate(InvoiceGenerationParams params) {

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -1,17 +1,64 @@
 package io.alapierre.ksef.fop;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.Singular;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Data
 @Builder
 @NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpoGenerationParams {
-    
+
     @NotNull
     private UpoSchema schema;
 
     @Builder.Default
     private Language language = Language.PL;
+
+    /**
+     * Optional classpath-relative path to a custom XSLT UPO template.
+     * When set, overrides the schema-derived default template path.
+     */
+    @Nullable
+    private String templatePath;
+
+    /**
+     * Ordered list of filesystem directories searched before the classpath when resolving templates.
+     */
+    @Singular("templateRoot")
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    private List<Path> templateRoots;
+
+    /**
+     * @deprecated use the builder instead.
+     */
+    @Deprecated
+    public UpoGenerationParams(@NotNull UpoSchema schema, Language language) {
+        this.schema = schema;
+        this.language = language != null ? language : Language.PL;
+        this.templatePath = null;
+        this.templateRoots = Collections.emptyList();
+    }
+
+    /**
+     * Returns an unmodifiable view of the configured filesystem template roots.
+     */
+    public List<Path> getTemplateRoots() {
+        if (templateRoots == null) return Collections.emptyList();
+        return Collections.unmodifiableList(templateRoots);
+    }
 }

--- a/src/main/java/io/alapierre/ksef/fop/internal/Strings.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/Strings.java
@@ -13,7 +13,17 @@ public final class Strings {
      * @return {@code defaultStr} if {@code str} is {@code null} or empty; otherwise, returns {@code str}
      */
     public static String defaultIfEmpty(String str, String defaultStr) {
-        return str == null || str.isEmpty() ? defaultStr : str;
+        return isEmpty(str) ? defaultStr : str;
+    }
+
+    /**
+     * Checks if the input string is null or empty.
+     *
+     * @param str the string to check
+     * @return {@code true} if {@code str} is {@code null} or empty
+     */
+    public static boolean isEmpty(String str) {
+        return str == null || str.isEmpty();
     }
 
     private Strings() {

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-identifier: Apache-2.0
+ */
+package io.alapierre.ksef.fop.internal;
+
+import net.sf.saxon.trans.NonDelegatingURIResolver;
+import org.xmlresolver.CatalogManager;
+import org.xmlresolver.ResolverFeature;
+import org.xmlresolver.XMLResolverConfiguration;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * URI resolver for XSLT template loading.
+ *
+ * <p>Every resource is looked up in the following order:</p>
+ * <ol>
+ *   <li>If the resource name starts with {@code http:} or {@code https:}, it is resolved
+ *       using an XML catalog.</li>
+ *   <li>Each configured filesystem root, in insertion order.</li>
+ *   <li>Classpath.</li>
+ * </ol>
+ * <p>Anything unresolved throws {@link TransformerException}.</p>
+ *
+ * <p><strong>Containment guarantee.</strong> For each filesystem root, the resolved path is
+ * verified to remain within the root. Both {@code ..} traversal and symlinks pointing outside
+ * the root are rejected.</p>
+ *
+ * <p>System IDs produced by this resolver use the {@code vfs:} scheme
+ * (e.g. {@code vfs:///templates/fa3/ksef_invoice.xsl}) so that Saxon treats them as
+ * absolute and does not attempt to resolve them against the JVM working directory.</p>
+ *
+ * <p>This class is <strong>internal</strong> and may change between releases.</p>
+ */
+public class TemplateResolver implements NonDelegatingURIResolver {
+
+    public static final String HTTP_PREFIX = "http://";
+    public static final String HTTPS_PREFIX = "https://";
+    private static final String VFS_SCHEME = "vfs";
+    private static final String VFS_PREFIX = VFS_SCHEME + ":///";
+    private static final URI VFS_ROOT = URI.create(VFS_PREFIX);
+
+    private final List<Path> roots;
+    private final CatalogManager catalogManager;
+
+    public TemplateResolver(List<Path> roots) throws TransformerException {
+        this.roots = new ArrayList<>(roots.size());
+        for (Path root : roots) {
+            this.roots.add(canonicalize(root));
+        }
+        XMLResolverConfiguration config = new XMLResolverConfiguration();
+        config.setFeature(ResolverFeature.CATALOG_FILES,
+                Collections.singletonList("classpath:catalog.xml"));
+        this.catalogManager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
+    }
+
+    @Override
+    public Source resolve(String href, String base) throws TransformerException {
+        if (href == null) {
+            throw new TransformerException("Cannot resolve null href");
+        }
+
+        // 1. http: / https: URIs → XML catalog (allowlist); anything not listed throws
+        if (href.startsWith(HTTP_PREFIX) || href.startsWith(HTTPS_PREFIX)) {
+            URI mapped = catalogManager.lookupURI(href);
+            if (mapped == null) {
+                throw new TransformerException("External URI not in catalog: " + href);
+            }
+            if (!"classpath".equals(mapped.getScheme())) {
+                throw new TransformerException("Catalog must map to a classpath: URI, got: " + mapped);
+            }
+            href = "/" + mapped.getSchemeSpecificPart();
+        }
+
+        // Reject any remaining URI scheme
+        if (href.contains(":")) {
+            throw new TransformerException("Unsupported URI scheme in href: " + href);
+        }
+
+        // 2 + 3. Derive the effective relative path, then try filesystem roots and classpath
+        URI baseUri = parseBase(base);
+        URI virtualUri = resolveUri(baseUri, href);
+        // Remove leading slash
+        String relativePath = virtualUri.getPath().substring(1);
+
+        for (Path root : roots) {
+            Source s = tryFilesystem(root, relativePath);
+            if (s != null) return s;
+        }
+
+        Source s = tryClasspath(relativePath);
+        if (s != null) return s;
+
+        throw new TransformerException("Template not found: " + href + (Strings.isEmpty(base) ? "" : " (base: " + base + ")"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Effective path computation
+    // -----------------------------------------------------------------------
+
+    /**
+     * Canonicalises {@code path} via {@code toRealPath()}, resolving symlinks and {@code ..} segments.
+     */
+    private static Path canonicalize(Path path) throws TransformerException {
+        try {
+            return path.toRealPath();
+        } catch (IOException e) {
+            throw new TransformerException("File is not accessible: " + path, e);
+        }
+    }
+
+    /**
+     * Returns {@code uri} unchanged if its scheme is {@code vfs:}, otherwise throws.
+     */
+    private static URI requireVfsScheme(URI uri) throws TransformerException {
+        if (!VFS_SCHEME.equals(uri.getScheme())) {
+            throw new TransformerException("Unexpected URI scheme: " + uri);
+        }
+        return uri;
+    }
+
+    /**
+     * Parses and validates {@code base}.
+     *
+     * @return {@link #VFS_ROOT} if {@code base} is absent (entry-point call), or the parsed URI
+     * @throws TransformerException if {@code base} is not a valid URI or not a {@code vfs:} URI
+     */
+    private static URI parseBase(String base) throws TransformerException {
+        if (Strings.isEmpty(base)) {
+            return VFS_ROOT;
+        }
+        return requireVfsScheme(parseUri(base));
+    }
+
+    /**
+     * Resolves {@code href} against {@code baseUri} and normalises the result.
+     */
+    private static URI resolveUri(URI baseUri, String href) throws TransformerException {
+        return baseUri.resolve(encodePathUri(href)).normalize();
+    }
+
+    /**
+     * Parses {@code uri} as a URI, rethrowing {@link URISyntaxException} as {@link TransformerException}.
+     */
+    private static URI parseUri(String uri) throws TransformerException {
+        try {
+            return new URI(uri);
+        } catch (URISyntaxException e) {
+            throw new TransformerException("Invalid resource path: " + uri, e);
+        }
+    }
+
+    /**
+     * Wraps {@code path} in a scheme-less relative URI, percent-encoding any reserved characters.
+     */
+    private static URI encodePathUri(String path) throws TransformerException {
+        try {
+            return new URI(null, null, path, null);
+        } catch (URISyntaxException e) {
+            // Should never occur
+            throw new TransformerException("Invalid resource path: " + path, e);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Lookup strategies
+    // -----------------------------------------------------------------------
+
+    /**
+     * Tries to load {@code relativePath} from under {@code root}.
+     *
+     * <p>Containment check: after resolving symlinks via {@code toRealPath()}, the real path must
+     * remain under {@code root}.</p>
+     */
+    private static Source tryFilesystem(Path root, String relativePath) throws TransformerException {
+        Path candidate = root.resolve(relativePath);
+        if (!Files.exists(candidate)) {
+            return null;
+        }
+
+        // Resolve symlinks to check for symlink escape or path traversal.
+        try {
+            Path realCandidate = candidate.toRealPath();
+            if (!realCandidate.startsWith(root)) {
+                throw new TransformerException("Path traversal rejected: " + relativePath);
+            }
+            return new StreamSource(Files.newInputStream(realCandidate), VFS_PREFIX + relativePath);
+        } catch (NoSuchFileException e) {
+            // TOCTOU: the file disappeared after the check
+            // The caller will throw an appropriate error.
+            return null;
+        } catch (IOException e) {
+            throw new TransformerException("File is not accessible: " + candidate, e);
+        }
+    }
+
+    /**
+     * Tries to load {@code path} as a classpath resource.
+     */
+    private static Source tryClasspath(String relativePath) {
+        InputStream is = TemplateResolver.class.getClassLoader().getResourceAsStream(relativePath);
+        if (is == null) return null;
+        return new StreamSource(is, VFS_PREFIX + relativePath);
+    }
+}

--- a/src/main/resources/catalog.xml
+++ b/src/main/resources/catalog.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <uri name="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/KodyKrajow_v10-0E.xsd"
+         uri="xsd/KodyKrajow_v10-0E.xsd"/>
+</catalog>

--- a/src/test/java/io/alapierre/ksef/fop/CustomTemplateOverrideTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/CustomTemplateOverrideTest.java
@@ -5,10 +5,14 @@ import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,42 +20,133 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CustomTemplateOverrideTest {
 
-    private static InputStream getResourceAsStream(String path) {
-        return CustomTemplateOverrideTest.class.getClassLoader().getResourceAsStream(path);
+    private static final String FILESYSTEM_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<xsl:stylesheet version=\"1.0\"\n"
+            + "                xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\"\n"
+            + "                xmlns:fo=\"http://www.w3.org/1999/XSL/Format\">\n"
+            + "    <xsl:param name=\"labels\"/>\n"
+            + "    <xsl:param name=\"nrKsef\"/>\n"
+            + "    <xsl:param name=\"issuerUser\"/>\n"
+            + "    <xsl:param name=\"showFooter\"/>\n"
+            + "    <xsl:param name=\"useExtendedDecimalPlaces\"/>\n"
+            + "    <xsl:param name=\"showCorrectionDifferences\"/>\n"
+            + "    <xsl:param name=\"duplicateDate\"/>\n"
+            + "    <xsl:param name=\"currencyDate\"/>\n"
+            + "    <xsl:param name=\"qrCodesCount\"/>\n"
+            + "    <xsl:param name=\"customPropertyDemo\"/>\n"
+            + "    <xsl:template match=\"/\">\n"
+            + "        <fo:root>\n"
+            + "            <fo:layout-master-set>\n"
+            + "                <fo:simple-page-master master-name=\"A4\"\n"
+            + "                                       page-height=\"29.7cm\"\n"
+            + "                                       page-width=\"21cm\"\n"
+            + "                                       margin=\"1cm\">\n"
+            + "                    <fo:region-body/>\n"
+            + "                </fo:simple-page-master>\n"
+            + "            </fo:layout-master-set>\n"
+            + "            <fo:page-sequence master-reference=\"A4\">\n"
+            + "                <fo:flow flow-name=\"xsl-region-body\">\n"
+            + "                    <fo:block font-size=\"12pt\" font-family=\"Helvetica\">\n"
+            + "                        FILESYSTEM_TEMPLATE_MARKER\n"
+            + "                    </fo:block>\n"
+            + "                    <fo:block font-size=\"10pt\" font-family=\"Helvetica\">\n"
+            + "                        <xsl:text>nrKsef=</xsl:text>\n"
+            + "                        <xsl:value-of select=\"$nrKsef\"/>\n"
+            + "                    </fo:block>\n"
+            + "                    <fo:block font-size=\"10pt\" font-family=\"Helvetica\">\n"
+            + "                        <xsl:text>customPropertyDemo=</xsl:text>\n"
+            + "                        <xsl:value-of select=\"$customPropertyDemo\"/>\n"
+            + "                    </fo:block>\n"
+            + "                </fo:flow>\n"
+            + "            </fo:page-sequence>\n"
+            + "        </fo:root>\n"
+            + "    </xsl:template>\n"
+            + "</xsl:stylesheet>\n";
+
+    @Test
+    void generateInvoice_usesClasspathTemplatePath() throws Exception {
+        InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                .schema(InvoiceSchema.FA3_1_0_E)
+                .ksefNumber("TEST-KSEF-NUMBER")
+                .templatePath("templates/custom/custom_invoice.xsl")
+                .customProperties(Collections.singletonMap("customPropertyDemo", "HELLO-CUSTOM-PROPERTY"))
+                .build();
+
+        String text = generateAndExtractText(params);
+
+        assertTrue(text.contains("CUSTOM_TEMPLATE_MARKER"), "Expected classpath template marker in PDF");
+        assertTrue(text.contains("nrKsef=TEST-KSEF-NUMBER"), "Expected nrKsef parameter in PDF");
+        assertTrue(text.contains("customPropertyDemo=HELLO-CUSTOM-PROPERTY"), "Expected custom property in PDF");
     }
 
-    private static String extractTextFromPdf(byte[] pdfData) throws IOException {
-        try (PDDocument document = Loader.loadPDF(pdfData)) {
+    @Test
+    void generateInvoice_usesFilesystemTemplateRoot(@TempDir Path tempDir) throws Exception {
+        Path templateDir = tempDir.resolve("templates/custom");
+        Files.createDirectories(templateDir);
+        Files.write(templateDir.resolve("custom_invoice.xsl"),
+                FILESYSTEM_TEMPLATE.getBytes(StandardCharsets.UTF_8));
+
+        InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                .schema(InvoiceSchema.FA3_1_0_E)
+                .ksefNumber("FS-KSEF-NUMBER")
+                .templatePath("templates/custom/custom_invoice.xsl")
+                .customProperties(Collections.singletonMap("customPropertyDemo", "HELLO-FS-PROPERTY"))
+                .templateRoot(tempDir)
+                .build();
+
+        String text = generateAndExtractText(params);
+
+        assertTrue(text.contains("FILESYSTEM_TEMPLATE_MARKER"), "Expected filesystem template marker in PDF");
+        assertTrue(text.contains("nrKsef=FS-KSEF-NUMBER"), "Expected nrKsef parameter in PDF");
+        assertTrue(text.contains("customPropertyDemo=HELLO-FS-PROPERTY"), "Expected custom property in PDF");
+    }
+
+    @Test
+    void generateInvoice_filesystemRootShadowsClasspath(@TempDir Path tempDir) throws Exception {
+        Path templateDir = tempDir.resolve("templates/custom");
+        Files.createDirectories(templateDir);
+        Files.write(templateDir.resolve("custom_invoice.xsl"),
+                FILESYSTEM_TEMPLATE.getBytes(StandardCharsets.UTF_8));
+
+        InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                .schema(InvoiceSchema.FA3_1_0_E)
+                .ksefNumber("SHADOW-TEST")
+                .templatePath("templates/custom/custom_invoice.xsl")
+                .templateRoot(tempDir)
+                .build();
+
+        String text = generateAndExtractText(params);
+
+        assertTrue(text.contains("FILESYSTEM_TEMPLATE_MARKER"), "Filesystem root must shadow classpath");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static String generateAndExtractText(InvoiceGenerationParams params) throws Exception {
+        try (InputStream fopCfg = resource("fop.xconf");
+             InputStream invoiceIs = resource("faktury/fa3/podstawowa/FA_3_Przyklad_1.xml")) {
+            assertNotNull(fopCfg);
+            assertNotNull(invoiceIs);
+
+            PdfGenerator generator = new PdfGenerator(fopCfg);
+            byte[] invoiceXml = IOUtils.toByteArray(invoiceIs);
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            generator.generateInvoice(invoiceXml, params, out);
+
+            return extractText(out.toByteArray());
+        }
+    }
+
+    private static String extractText(byte[] pdf) throws IOException {
+        try (PDDocument document = Loader.loadPDF(pdf)) {
             return new PDFTextStripper().getText(document);
         }
     }
 
-    @Test
-    void generateInvoice_usesProvidedTemplatePath() throws Exception {
-        try (InputStream fopCfg = getResourceAsStream("fop.xconf")) {
-            assertNotNull(fopCfg);
-            PdfGenerator generator = new PdfGenerator(fopCfg);
-
-            try (InputStream invoiceIs = getResourceAsStream("faktury/fa3/podstawowa/FA_3_Przyklad_1.xml")) {
-                assertNotNull(invoiceIs);
-                byte[] invoiceXml = IOUtils.toByteArray(invoiceIs);
-
-                InvoiceGenerationParams params = InvoiceGenerationParams.builder()
-                        .schema(InvoiceSchema.FA3_1_0_E)
-                        .ksefNumber("TEST-KSEF-NUMBER")
-                        .templatePath("templates/custom/custom_invoice.xsl")
-                        .customProperties(Collections.singletonMap("customPropertyDemo", "HELLO-CUSTOM-PROPERTY"))
-                        .build();
-
-                ByteArrayOutputStream out = new ByteArrayOutputStream();
-                generator.generateInvoice(invoiceXml, params, out);
-
-                String text = extractTextFromPdf(out.toByteArray());
-                assertTrue(text.contains("CUSTOM_TEMPLATE_MARKER"), "Expected marker from custom template in PDF text");
-                assertTrue(text.contains("nrKsef=TEST-KSEF-NUMBER"), "Expected nrKsef parameter rendered by custom template");
-                assertTrue(text.contains("customPropertyDemo=HELLO-CUSTOM-PROPERTY"), "Expected custom property rendered by custom template");
-            }
-        }
+    private static InputStream resource(String path) {
+        return CustomTemplateOverrideTest.class.getClassLoader().getResourceAsStream(path);
     }
 }
-

--- a/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
@@ -1,0 +1,276 @@
+package io.alapierre.ksef.fop.internal;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TemplateResolverTest {
+
+    // -----------------------------------------------------------------------
+    // Filesystem root lookup
+    // -----------------------------------------------------------------------
+
+    @Test
+    void findsTemplateInFirstRoot(@TempDir Path root) throws Exception {
+        Path file = root.resolve("my-template.xsl");
+        write(file, "<xsl/>");
+
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        Source source = resolver.resolve("my-template.xsl", "");
+
+        assertThat(source).isNotNull();
+        assertThat(source.getSystemId()).endsWith("my-template.xsl");
+    }
+
+    @Test
+    void fallsThroughToSecondRootWhenFirstMisses(@TempDir Path root1, @TempDir Path root2) throws Exception {
+        Path file = root2.resolve("found-in-second.xsl");
+        write(file, "<xsl/>");
+
+        TemplateResolver resolver = new TemplateResolver(Arrays.asList(root1, root2));
+        Source source = resolver.resolve("found-in-second.xsl", "");
+
+        assertThat(source).isNotNull();
+        assertThat(source.getSystemId()).endsWith("found-in-second.xsl");
+    }
+
+    @Test
+    void templateInFirstRootShadowsSecondRoot(@TempDir Path root1, @TempDir Path root2) throws Exception {
+        write(root1.resolve("template.xsl"), "root1");
+        write(root2.resolve("template.xsl"), "root2");
+
+        TemplateResolver resolver = new TemplateResolver(Arrays.asList(root1, root2));
+        Source source = resolver.resolve("template.xsl", "");
+
+        assertThat(source).isInstanceOf(StreamSource.class);
+        StreamSource ss = (StreamSource) source;
+        try (InputStream is = ss.getInputStream()) {
+            String content = new String(IOUtils.toByteArray(is), StandardCharsets.UTF_8);
+            assertThat(content).isEqualTo("root1");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Classpath fallback
+    // -----------------------------------------------------------------------
+
+    @Test
+    void fallsBackToClasspathWhenNoRootMatches() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+        Source source = resolver.resolve("templates/fa3/ksef_invoice.xsl", "");
+
+        assertThat(source).isNotNull();
+        assertThat(source.getSystemId()).endsWith("templates/fa3/ksef_invoice.xsl");
+    }
+
+    @Test
+    void emptyRootListUsesClasspathOnly() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+        Source source = resolver.resolve("templates/fa2/ksef_invoice.xsl", "");
+
+        assertThat(source).isNotNull();
+    }
+
+    @Test
+    void findsTemplateWithSpaceInName(@TempDir Path root) throws Exception {
+        Path file = root.resolve("my template.xsl");
+        write(file, "<xsl/>");
+
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        Source source = resolver.resolve("my template.xsl", "");
+
+        assertThat(source).isNotNull();
+        assertThat(source.getSystemId()).contains("my template.xsl");
+    }
+
+    // -----------------------------------------------------------------------
+    // Relative include chain
+    // -----------------------------------------------------------------------
+
+    @Test
+    void resolvesRelativeIncludeAgainstBase() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+        Source source = resolver.resolve("common-functions.xsl", "vfs:///templates/fa3/ksef_invoice.xsl");
+
+        assertThat(source).isNotNull();
+        assertThat(source.getSystemId()).isEqualTo("vfs:///templates/fa3/common-functions.xsl");
+    }
+
+    @Test
+    void resolvesRelativeIncludeFromFilesystemRoot(@TempDir Path root) throws Exception {
+        Path subDir = root.resolve("templates/custom");
+        Files.createDirectories(subDir);
+        write(subDir.resolve("main.xsl"), "<main/>");
+        write(subDir.resolve("included.xsl"), "<included/>");
+        write(root.resolve("templates").resolve("shared.xsl"), "<shared/>");
+
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+
+        // First: entry point
+        Source main = resolver.resolve("templates/custom/main.xsl", "");
+        assertThat(main).isNotNull();
+
+        // Second: relative include resolved against entry-point system ID
+        Source included = resolver.resolve("included.xsl", "vfs:///templates/custom/main.xsl");
+        assertThat(included).isNotNull();
+        assertThat(included.getSystemId()).isEqualTo("vfs:///templates/custom/included.xsl");
+
+        // Third: parent-relative include from templates/custom/ up to templates/
+        Source shared = resolver.resolve("../shared.xsl", "vfs:///templates/custom/included.xsl");
+        assertThat(shared).isNotNull();
+        assertThat(shared.getSystemId()).isEqualTo("vfs:///templates/shared.xsl");
+    }
+
+    // -----------------------------------------------------------------------
+    // Catalog / HTTP URIs
+    // -----------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/KodyKrajow_v10-0E.xsd",
+            "https://example.com/KodyKrajow_v10-0E.xsd"
+    })
+    void resolvesKodyKrajowViaXmlCatalog(String url) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+        Source source = resolver.resolve(url, "");
+
+        assertThat(source).isNotNull();
+    }
+
+    @Test
+    void unknownHttpUriThrows() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+
+        assertThatThrownBy(() ->
+                resolver.resolve("http://attacker.example.com/evil.xsl", ""))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "file:///etc/passwd",
+            "ftp://example.com/evil.xsl",
+            "data:text/xml,<xsl/>",
+            "vfs:///templates/fa3/ksef_invoice.xsl"
+    })
+    void nonHttpSchemeInHrefThrows(String href) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+
+        assertThatThrownBy(() ->
+                resolver.resolve(href, ""))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // Security: path traversal
+    // -----------------------------------------------------------------------
+
+    @Test
+    void dotDotTraversalIsRejected(@TempDir Path root) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+
+        assertThatThrownBy(() ->
+                resolver.resolve("../../etc/passwd", null))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    @Test
+    void dotDotInBaseDoesNotEscapeRoot(@TempDir Path root) throws Exception {
+        // Trying to escape via a crafted base
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+
+        assertThatThrownBy(() ->
+                resolver.resolve("../../../etc/passwd", "vfs:///templates/fa3/ksef_invoice.xsl"))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void symlinkEscapingRootIsRejected(@TempDir Path root, @TempDir Path outside) throws Exception {
+        // Create a file outside the root
+        Path target = outside.resolve("secret.xsl");
+        write(target, "<secret/>");
+
+        // Create a symlink inside root pointing outside
+        Path link = root.resolve("evil.xsl");
+        Files.createSymbolicLink(link, target);
+
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+
+        assertThatThrownBy(() ->
+                resolver.resolve("evil.xsl", ""))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // Missing template
+    // -----------------------------------------------------------------------
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "vfs:///templates"})
+    void missingTemplateThrows(String base, @TempDir Path root) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+
+        assertThatThrownBy(() ->
+                resolver.resolve("nonexistent.xsl", base))
+                .isInstanceOf(TransformerException.class)
+                .hasMessageContaining("nonexistent.xsl");
+    }
+
+    // -----------------------------------------------------------------------
+    // Invalid base/href
+    // -----------------------------------------------------------------------
+
+    @Test
+    void invalidBaseThrows() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+
+        assertThatThrownBy(() ->
+                resolver.resolve("", "invalid URI"))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    @Test
+    void invalidHrefThrows() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+
+        assertThatThrownBy(() ->
+                resolver.resolve(null, ""))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static void write(Path path, String content) throws IOException {
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void nonVfsBaseThrows() throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+
+        assertThatThrownBy(() ->
+                resolver.resolve("template.xsl", "file:///some/path/main.xsl"))
+                .isInstanceOf(TransformerException.class);
+    }
+}

--- a/src/test/resources/catalog.xml
+++ b/src/test/resources/catalog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <!-- External URLs resolve to a resource file with or without leading '/' -->
+    <uri name="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/KodyKrajow_v10-0E.xsd"
+         uri="xsd/KodyKrajow_v10-0E.xsd"/>
+    <uri name="https://example.com/KodyKrajow_v10-0E.xsd"
+         uri="/xsd/KodyKrajow_v10-0E.xsd"/>
+</catalog>


### PR DESCRIPTION
This change is an alternative to #120, adding support for filesystem templates. It implements a `TemplateResolver` that resolves each resource in order:

- Via an XML catalog that maps external URIs to classpath resources.
- Against an ordered list of filesystem roots, configured via `templateRoot()` on `InvoiceGenerationParamsBuilder`.
- Against the classpath as a fallback.

Custom resolver logic is removed from `PdfGenerator`; everything now goes through `TemplateResolver`. The same changes are applied to `UpoGenerationParams`, which was missed in earlier enhancements.

Path traversal and symlink escapes are prevented: any resolved path outside the root is rejected. Any `href` containing a URI scheme other than `http:`/`https:` is also rejected.

This has multiple applications:
- Users can specify their top-level stylesheet from either the filesystem or the classpath.
- Users can override specific sub-templates by placing files in a higher-priority filesystem root.

The class is kept internal until the API reaches its final form, which could be extended to support classpath roots as well.

Assisted-By: Claude Sonnet 4.6 <noreply@anthropic.com>
