### PR TITLE
allow customizing default XML parser factory for translations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -212,8 +212,66 @@ supplied one).
   roots are rejected up front.
 - Every resource loaded from a root must remain under it (`..` escapes and symlink
   escapes are rejected — the lookup silently falls through to the classpath).
-- The XML parser used for labels runs with `FEATURE_SECURE_PROCESSING`, DTDs disabled,
-  and external entity resolution disabled — overrides cannot perform XXE attacks.
+- By default, the XML parser used for labels runs with `FEATURE_SECURE_PROCESSING`,
+  DTDs disabled, and external entity resolution disabled.
+
+### Customizing translation XML parser factory
+
+If needed, you can customize the default `DocumentBuilderFactory` used for translation
+XML parsing. The library creates its default secure factory first, then invokes your
+customizer.
+
+Default factory configuration applied by the library:
+
+- `setNamespaceAware(false)`
+- `setValidating(false)`
+- `setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)`
+- `setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)`
+- `setFeature("http://xml.org/sax/features/external-general-entities", false)`
+- `setFeature("http://xml.org/sax/features/external-parameter-entities", false)`
+- `setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)`
+- `setXIncludeAware(false)`
+- `setExpandEntityReferences(false)`
+- `setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")`
+- `setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")`
+
+Invoice example:
+
+````java
+InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+        .schema(InvoiceSchema.FA3_1_0_E)
+        .languageLocale("en")
+        .translationDocumentBuilderFactoryCustomizer(factory -> {
+            try {
+                // Example: keep secure processing, but tweak parser-specific settings.
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            } catch (ParserConfigurationException e) {
+                throw new IllegalStateException("Invalid XML parser feature", e);
+            }
+        })
+        .build();
+````
+
+UPO example:
+
+````java
+UpoGenerationParams params = UpoGenerationParams.builder()
+        .schema(UpoSchema.UPO_V4_3)
+        .languageLocale("pl")
+        .translationDocumentBuilderFactoryCustomizer(factory -> {
+            try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (ParserConfigurationException e) {
+                throw new IllegalStateException(e);
+            }
+        })
+        .build();
+````
+
+> **Important:** customizer runs on your responsibility. If you weaken XML parser
+> settings, you can re-enable XXE-style risks.
 
 ### Using `TranslationService` directly
 

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -11,6 +11,7 @@ import lombok.Singular;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 @Data
 @Builder
@@ -93,6 +95,17 @@ public class InvoiceGenerationParams {
     private String languageLocale;
 
     /**
+     * Optional customizer invoked on top of the library's default translation XML
+     * {@link DocumentBuilderFactory} settings.
+     *
+     * <p>The library always creates a default hardened factory first and then invokes this
+     * customizer (if provided), so callers can adjust existing properties and add parser-
+     * specific options in one place.</p>
+     */
+    @Nullable
+    private Consumer<DocumentBuilderFactory> translationDocumentBuilderFactoryCustomizer;
+
+    /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
     @Singular("templateRoot")
@@ -130,6 +143,7 @@ public class InvoiceGenerationParams {
         this.customProperties = customProperties != null ? customProperties : new HashMap<>();
         this.language = language != null ? language : Language.PL;
         this.languageLocale = null;
+        this.translationDocumentBuilderFactoryCustomizer = null;
         this.templateRoots = Collections.emptyList();
     }
 

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -89,7 +89,9 @@ public class PdfGenerator {
         Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
         TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots());
-        TranslationService translationService = new TranslationService(resolver);
+        TranslationService translationService = new TranslationService(
+                resolver,
+                params.getTranslationDocumentBuilderFactoryCustomizer());
         Transformer transformer = createTransformer(resolver, resolveUpoTemplatePath(params));
         applyLabelParameters(translationService, params.resolveLanguageTag(), transformer);
 
@@ -113,7 +115,9 @@ public class PdfGenerator {
                                 OutputStream out) throws TransformerException, FOPException {
         String langCode = params.resolveLanguageTag();
         TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots());
-        TranslationService translationService = new TranslationService(resolver);
+        TranslationService translationService = new TranslationService(
+                resolver,
+                params.getTranslationDocumentBuilderFactoryCustomizer());
         QrCodeBuilder qrCodeBuilder = new QrCodeBuilder(translationService);
         List<QrCodeData> qrCodes = qrCodeBuilder.buildQrCodes(params.getInvoiceQRCodeGeneratorRequest(), params.getKsefNumber(), invoiceXml, langCode);
         generatePdfInvoice(invoiceXml, params, qrCodes, null, resolver, translationService, out);
@@ -137,7 +141,9 @@ public class PdfGenerator {
                                          LocalDate duplicateDate,
                                          OutputStream out) throws TransformerException, FOPException {
         TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots());
-        TranslationService translationService = new TranslationService(resolver);
+        TranslationService translationService = new TranslationService(
+                resolver,
+                params.getTranslationDocumentBuilderFactoryCustomizer());
         generatePdfInvoice(invoiceXml, params, null, duplicateDate, resolver, translationService, out);
     }
 

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -11,9 +11,11 @@ import lombok.Singular;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.xml.parsers.DocumentBuilderFactory;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 @Data
 @Builder
@@ -46,6 +48,17 @@ public class UpoGenerationParams {
     private String languageLocale;
 
     /**
+     * Optional customizer invoked on top of the library's default translation XML
+     * {@link DocumentBuilderFactory} settings.
+     *
+     * <p>The library always creates a default hardened factory first and then invokes this
+     * customizer (if provided), so callers can adjust existing properties and add parser-
+     * specific options in one place.</p>
+     */
+    @Nullable
+    private Consumer<DocumentBuilderFactory> translationDocumentBuilderFactoryCustomizer;
+
+    /**
      * Optional classpath-relative path to a custom XSLT UPO template.
      * When set, overrides the schema-derived default template path.
      */
@@ -68,6 +81,7 @@ public class UpoGenerationParams {
         this.schema = schema;
         this.language = language != null ? language : Language.PL;
         this.languageLocale = null;
+        this.translationDocumentBuilderFactoryCustomizer = null;
         this.templatePath = null;
         this.templateRoots = Collections.emptyList();
     }

--- a/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
+++ b/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
@@ -27,12 +27,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 
 @Slf4j
 public class TranslationService {
 
-    private static final DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY = createSecureDocumentBuilderFactory();
     private final Map<String, Document> DOCUMENT_CACHE = new ConcurrentHashMap<>();
 
     public static final String LABELS_BASE_NAME = "i18n/labels";
@@ -46,7 +46,7 @@ public class TranslationService {
 
     /** No-override service: labels come from the library classpath only. */
     public TranslationService() {
-        this(newClasspathOnlyResolver());
+        this(newClasspathOnlyResolver(), null);
     }
 
     /**
@@ -57,9 +57,26 @@ public class TranslationService {
      * and translations.</p>
      */
     public TranslationService(@NotNull URIResolver resolver) {
+        this(resolver, null);
+    }
+
+    /**
+     * Creates a translation service that loads labels through the supplied resolver and,
+     * optionally, customizes the default translation XML parser factory.
+     *
+     * <p>The service always starts from the library's hardened default factory and then
+     * invokes {@code documentBuilderFactoryCustomizer} (if provided), allowing callers to
+     * tweak existing settings and add parser-specific features/attributes.</p>
+     */
+    public TranslationService(@NotNull URIResolver resolver,
+                              @Nullable Consumer<DocumentBuilderFactory> documentBuilderFactoryCustomizer) {
         this.resolver = Objects.requireNonNull(resolver, "resolver");
+        DocumentBuilderFactory factory = createSecureDocumentBuilderFactory();
+        if (documentBuilderFactoryCustomizer != null) {
+            documentBuilderFactoryCustomizer.accept(factory);
+        }
         try {
-            this.documentBuilder = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+            this.documentBuilder = factory.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new IllegalStateException("Failed to initialize TranslationService", e);
         }

--- a/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -272,6 +273,30 @@ class TranslationServiceTest {
     @Test
     void constructor_shouldRejectNullResolver() {
         assertThrows(NullPointerException.class, () -> new TranslationService(null));
+    }
+
+    @Test
+    void constructor_shouldUseCustomDocumentBuilderFactoryCustomizer() throws TransformerException {
+        AtomicBoolean customizerCalled = new AtomicBoolean(false);
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+
+        TranslationService service = new TranslationService(
+                resolver,
+                factory -> {
+                    customizerCalled.set(true);
+                    factory.setNamespaceAware(true);
+                });
+
+        assertTrue(customizerCalled.get());
+        assertEquals("Numer faktury", service.getTranslation("pl", "invoice.number"));
+    }
+
+    @Test
+    void constructor_shouldPropagateCustomizerFailure() throws TransformerException {
+        TemplateResolver resolver = new TemplateResolver(Collections.emptyList());
+        assertThrows(IllegalArgumentException.class, () -> new TranslationService(resolver, factory -> {
+            throw new IllegalArgumentException("boom");
+        }));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added support for customizing the translation XML parser by exposing `translationDocumentBuilderFactoryCustomizer(...)` on generation params builders.
- Kept the library’s secure default `DocumentBuilderFactory` setup, then applied user customization on top.
- Documented usage for both invoice and UPO generation flows.

## Why
- Allows advanced parser tuning when needed while preserving secure defaults out of the box.
- Gives integrators controlled extensibility for translation XML parsing without forking parser setup logic.

## Notes
- Customizer is powerful and can weaken XML security if misused; responsibility remains on the integrator.