### PR TITLE
chore: clean-up unused `createSecureDocumentBuilderFactory`

### DIFF
--- a/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
+++ b/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
@@ -14,9 +14,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
@@ -293,29 +291,5 @@ public class TranslationService {
         } catch (TransformerException e) {
             throw new IllegalStateException("Failed to build default TranslationService resolver", e);
         }
-    }
-
-    // -----------------------------------------------------------------------
-    // Secure parser configuration
-    // -----------------------------------------------------------------------
-
-    private static DocumentBuilderFactory createSecureDocumentBuilderFactory() {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(false);
-        factory.setValidating(false);
-        try {
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        } catch (ParserConfigurationException e) {
-            throw new IllegalStateException("Unable to secure XML parser for translations", e);
-        }
-        factory.setXIncludeAware(false);
-        factory.setExpandEntityReferences(false);
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        return factory;
     }
 }


### PR DESCRIPTION
The method is a left-over of the introduction of `XmlFactories.DOCUMENT_BUILDER_FACTORY`.

The configuration of the DOM factory in `XmlFactories` is much shorter, but as effective: if `DOCTYPE` declarations are disabled (the parser throws when present), then no external DTD or entities handling occurs.
