### PR TITLE
Ensure transport and carrier table cells always have block content

### DIFF
--- a/src/main/resources/templates/fa3/ksef_invoice.xsl
+++ b/src/main/resources/templates/fa3/ksef_invoice.xsl
@@ -3597,67 +3597,81 @@
                             <fo:table-row>
                                 <fo:table-cell xsl:use-attribute-sets="table.cell.transport">
                                     <xsl:variable name="di" select="crd:Przewoznik/crd:DaneIdentyfikacyjne"/>
-                                    <xsl:if test="$di/crd:NIP">
-                                        <fo:block font-size="7pt" space-after="1mm">
-                                            <fo:inline font-weight="600">
-                                                <xsl:value-of select="key('kLabels', 'nip', $labels)"/>
-                                                <xsl:text>: </xsl:text>
-                                            </fo:inline>
-                                            <xsl:value-of select="$di/crd:NIP"/>
-                                        </fo:block>
-                                    </xsl:if>
-                                    <xsl:if test="$di/crd:NrVatUE">
-                                        <fo:block font-size="7pt" space-after="1mm">
-                                            <fo:inline font-weight="600">
-                                                <xsl:value-of select="key('kLabels', 'vatUe.number', $labels)"/>
-                                                <xsl:text>: </xsl:text>
-                                            </fo:inline>
-                                            <xsl:if test="$di/crd:KodUE">
-                                                <xsl:value-of select="$di/crd:KodUE"/>
+                                    <xsl:choose>
+                                        <xsl:when test="$di/crd:NIP | $di/crd:NrVatUE | $di/crd:NrID | $di/crd:BrakID | $di/crd:Nazwa">
+                                            <xsl:if test="$di/crd:NIP">
+                                                <fo:block font-size="7pt" space-after="1mm">
+                                                    <fo:inline font-weight="600">
+                                                        <xsl:value-of select="key('kLabels', 'nip', $labels)"/>
+                                                        <xsl:text>: </xsl:text>
+                                                    </fo:inline>
+                                                    <xsl:value-of select="$di/crd:NIP"/>
+                                                </fo:block>
                                             </xsl:if>
-                                            <xsl:value-of select="$di/crd:NrVatUE"/>
-                                        </fo:block>
-                                    </xsl:if>
-                                    <xsl:if test="$di/crd:NrID">
-                                        <fo:block font-size="7pt" space-after="1mm">
-                                            <fo:inline font-weight="600">
-                                                <xsl:value-of select="key('kLabels', 'taxId', $labels)"/>
-                                                <xsl:text>: </xsl:text>
-                                            </fo:inline>
-                                            <xsl:if test="$di/crd:KodKraju">
-                                                <xsl:value-of select="$di/crd:KodKraju"/>
-                                                <xsl:text> </xsl:text>
+                                            <xsl:if test="$di/crd:NrVatUE">
+                                                <fo:block font-size="7pt" space-after="1mm">
+                                                    <fo:inline font-weight="600">
+                                                        <xsl:value-of select="key('kLabels', 'vatUe.number', $labels)"/>
+                                                        <xsl:text>: </xsl:text>
+                                                    </fo:inline>
+                                                    <xsl:if test="$di/crd:KodUE">
+                                                        <xsl:value-of select="$di/crd:KodUE"/>
+                                                    </xsl:if>
+                                                    <xsl:value-of select="$di/crd:NrVatUE"/>
+                                                </fo:block>
                                             </xsl:if>
-                                            <xsl:value-of select="$di/crd:NrID"/>
-                                        </fo:block>
-                                    </xsl:if>
-                                    <xsl:if test="$di/crd:BrakID">
-                                        <fo:block font-size="7pt" space-after="1mm">
-                                            <fo:inline font-weight="600">
-                                                <xsl:value-of select="key('kLabels', 'podmiot3.brakIdentyfikatora', $labels)"/>
-                                            </fo:inline>
-                                        </fo:block>
-                                    </xsl:if>
-                                    <xsl:if test="$di/crd:Nazwa">
-                                        <fo:block font-size="7pt" space-after="1mm">
-                                            <fo:inline font-weight="600">
-                                                <xsl:value-of select="key('kLabels', 'name', $labels)"/>
-                                                <xsl:text>: </xsl:text>
-                                            </fo:inline>
-                                            <xsl:value-of select="$di/crd:Nazwa"/>
-                                        </fo:block>
-                                    </xsl:if>
+                                            <xsl:if test="$di/crd:NrID">
+                                                <fo:block font-size="7pt" space-after="1mm">
+                                                    <fo:inline font-weight="600">
+                                                        <xsl:value-of select="key('kLabels', 'taxId', $labels)"/>
+                                                        <xsl:text>: </xsl:text>
+                                                    </fo:inline>
+                                                    <xsl:if test="$di/crd:KodKraju">
+                                                        <xsl:value-of select="$di/crd:KodKraju"/>
+                                                        <xsl:text> </xsl:text>
+                                                    </xsl:if>
+                                                    <xsl:value-of select="$di/crd:NrID"/>
+                                                </fo:block>
+                                            </xsl:if>
+                                            <xsl:if test="$di/crd:BrakID">
+                                                <fo:block font-size="7pt" space-after="1mm">
+                                                    <fo:inline font-weight="600">
+                                                        <xsl:value-of select="key('kLabels', 'podmiot3.brakIdentyfikatora', $labels)"/>
+                                                    </fo:inline>
+                                                </fo:block>
+                                            </xsl:if>
+                                            <xsl:if test="$di/crd:Nazwa">
+                                                <fo:block font-size="7pt" space-after="1mm">
+                                                    <fo:inline font-weight="600">
+                                                        <xsl:value-of select="key('kLabels', 'name', $labels)"/>
+                                                        <xsl:text>: </xsl:text>
+                                                    </fo:inline>
+                                                    <xsl:value-of select="$di/crd:Nazwa"/>
+                                                </fo:block>
+                                            </xsl:if>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <fo:block font-size="7pt"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </fo:table-cell>
                                 <fo:table-cell xsl:use-attribute-sets="table.cell.transport">
-                                    <xsl:for-each select="crd:Przewoznik/crd:AdresPrzewoznika">
-                                        <fo:block font-size="7pt">
-                                            <xsl:call-template name="renderAddressAsBlocks">
-                                                <xsl:with-param name="label"
-                                                                select="key('kLabels', 'carrierAddress', $labels)"/>
-                                                <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
-                                            </xsl:call-template>
-                                        </fo:block>
-                                    </xsl:for-each>
+                                    <xsl:choose>
+                                        <xsl:when test="crd:Przewoznik/crd:AdresPrzewoznika">
+                                            <xsl:for-each select="crd:Przewoznik/crd:AdresPrzewoznika">
+                                                <fo:block font-size="7pt">
+                                                    <xsl:call-template name="renderAddressAsBlocks">
+                                                        <xsl:with-param name="label"
+                                                                        select="key('kLabels', 'carrierAddress', $labels)"/>
+                                                        <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
+                                                    </xsl:call-template>
+                                                </fo:block>
+                                            </xsl:for-each>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <fo:block font-size="7pt"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </fo:table-cell>
                             </fo:table-row>
                         </fo:table-body>
@@ -3673,35 +3687,49 @@
                         <fo:table-body>
                             <fo:table-row>
                                 <fo:table-cell xsl:use-attribute-sets="table.cell.transport">
-                                    <xsl:for-each select="crd:WysylkaZ">
-                                        <fo:block font-size="7pt">
-                                            <xsl:call-template name="renderAddressAsBlocks">
-                                                <xsl:with-param name="label"
-                                                                select="key('kLabels', 'transport.shippingFrom', $labels)"/>
-                                                <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
-                                            </xsl:call-template>
-                                        </fo:block>
-                                    </xsl:for-each>
-                                    <xsl:for-each select="crd:WysylkaPrzez">
-                                        <fo:block font-size="7pt" padding-top="2mm">
-                                            <xsl:call-template name="renderAddressAsBlocks">
-                                                <xsl:with-param name="label"
-                                                                select="key('kLabels', 'transport.shippingVia', $labels)"/>
-                                                <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
-                                            </xsl:call-template>
-                                        </fo:block>
-                                    </xsl:for-each>
+                                    <xsl:choose>
+                                        <xsl:when test="crd:WysylkaZ | crd:WysylkaPrzez">
+                                            <xsl:for-each select="crd:WysylkaZ">
+                                                <fo:block font-size="7pt">
+                                                    <xsl:call-template name="renderAddressAsBlocks">
+                                                        <xsl:with-param name="label"
+                                                                        select="key('kLabels', 'transport.shippingFrom', $labels)"/>
+                                                        <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
+                                                    </xsl:call-template>
+                                                </fo:block>
+                                            </xsl:for-each>
+                                            <xsl:for-each select="crd:WysylkaPrzez">
+                                                <fo:block font-size="7pt" padding-top="2mm">
+                                                    <xsl:call-template name="renderAddressAsBlocks">
+                                                        <xsl:with-param name="label"
+                                                                        select="key('kLabels', 'transport.shippingVia', $labels)"/>
+                                                        <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
+                                                    </xsl:call-template>
+                                                </fo:block>
+                                            </xsl:for-each>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <fo:block font-size="7pt"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </fo:table-cell>
                                 <fo:table-cell xsl:use-attribute-sets="table.cell.transport">
-                                    <xsl:for-each select="crd:WysylkaDo">
-                                        <fo:block font-size="7pt">
-                                            <xsl:call-template name="renderAddressAsBlocks">
-                                                <xsl:with-param name="label"
-                                                                select="key('kLabels', 'transport.shippingTo', $labels)"/>
-                                                <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
-                                            </xsl:call-template>
-                                        </fo:block>
-                                    </xsl:for-each>
+                                    <xsl:choose>
+                                        <xsl:when test="crd:WysylkaDo">
+                                            <xsl:for-each select="crd:WysylkaDo">
+                                                <fo:block font-size="7pt">
+                                                    <xsl:call-template name="renderAddressAsBlocks">
+                                                        <xsl:with-param name="label"
+                                                                        select="key('kLabels', 'transport.shippingTo', $labels)"/>
+                                                        <xsl:with-param name="labelPaddingTop" select="'0mm'"/>
+                                                    </xsl:call-template>
+                                                </fo:block>
+                                            </xsl:for-each>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <fo:block font-size="7pt"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </fo:table-cell>
                             </fo:table-row>
                         </fo:table-body>


### PR DESCRIPTION
## Summary

Fixes Apache FOP validation failures when FA(3) invoice XML includes transport/shipment or carrier data in a shape where one side of a two-column `fo:table` produced no block-level children (`fo:table-cell` must satisfy `marker* (%block;)+`).

## Root cause

- **Shipment:** The section is shown when any of `WysylkaZ`, `WysylkaPrzez`, or `WysylkaDo` is present, but the left column only renders `WysylkaZ` / `WysylkaPrzez` and the right only `WysylkaDo`. Valid XSD allows e.g. only `WysylkaDo`, which left the first cell empty and broke FOP.
- **Carrier:** `Przewoznik` could be present while identifier fields or `AdresPrzewoznika` were missing, leaving a column with no `fo:block`.

## Changes

- `ksef_invoice.xsl` (FA3): wrap affected cells in `xsl:choose` and emit a minimal `<fo:block font-size="7pt"/>` when that column has no real content.