### PR TITLE
Render `<Zamowienie>` order section for all invoice types

### DIFF
--- a/src/main/resources/i18n/labels.xml
+++ b/src/main/resources/i18n/labels.xml
@@ -86,6 +86,8 @@
     <entry key="positionsBeforeCorrection">Pozycje na fakturze przed korektą</entry>
     <entry key="difference">Różnica</entry>
     <entry key="positionsAfterCorrection">Pozycje na fakturze po korekcie</entry>
+    <entry key="orderBeforeCorrection">Pozycje zamówienia przed korektą</entry>
+    <entry key="orderAfterCorrection">Pozycje zamówienia po korekcie</entry>
     <entry key="grossAmountBeforeCorrection">Kwota brutto przed korektą</entry>
     <entry key="grossAmountAfterCorrection">Kwota brutto po korekcie</entry>
     <entry key="advancePaymentReceived">Otrzymana kwota zapłaty (zaliczki)</entry>

--- a/src/main/resources/i18n/labels_en.xml
+++ b/src/main/resources/i18n/labels_en.xml
@@ -86,6 +86,8 @@
     <entry key="positionsBeforeCorrection">Invoice items before correction</entry>
     <entry key="difference">Difference</entry>
     <entry key="positionsAfterCorrection">Invoice items after correction</entry>
+    <entry key="orderBeforeCorrection">Order items before correction</entry>
+    <entry key="orderAfterCorrection">Order items after correction</entry>
     <entry key="grossAmountBeforeCorrection">Gross amount before correction</entry>
     <entry key="grossAmountAfterCorrection">Gross amount after correction</entry>
     <entry key="advancePaymentReceived">Advance payment received</entry>

--- a/src/main/resources/templates/fa3/ksef_invoice.xsl
+++ b/src/main/resources/templates/fa3/ksef_invoice.xsl
@@ -84,7 +84,7 @@
     </xsl:template>
 
     <xsl:include href="invoice-rows.xsl"/>
-    <xsl:include href="order-invoice-rows.xsl"/>
+    <xsl:include href="order-invoice.xsl"/>
 
     <!--  Additional parameters that are not included in the xml invoice -->
     <xsl:param name="nrKsef"/>
@@ -933,7 +933,7 @@
 
                     <!-- Show positions section only if there are invoice lines or orders -->
 
-                    <xsl:if test="crd:Fa/crd:FaWiersz or crd:Fa/crd:Zamowienie/crd:ZamowienieWiersz or crd:Fa/crd:OkresFaKorygowanej">
+                    <xsl:if test="crd:Fa/crd:FaWiersz or crd:Fa/crd:Zamowienie or crd:Fa/crd:OkresFaKorygowanej">
                         <!-- Linia oddzielająca -->
                         <fo:block border-bottom="solid 1px grey" space-after="4mm" space-before="4mm"/>
 
@@ -956,8 +956,8 @@
                             </xsl:if>
                         </xsl:if>
 
-                        <!-- Section title: omitted for ZAL/KOR_ZAL (each subsection has its own title below) -->
-                        <xsl:if test="not(local:norm(crd:Fa/crd:RodzajFaktury) = 'ZAL') and not(local:norm(crd:Fa/crd:RodzajFaktury) = 'KOR_ZAL')">
+                        <!-- Section title: shown only when there are invoice lines or a correction period; the order section renders its own title -->
+                        <xsl:if test="crd:Fa/crd:FaWiersz or crd:Fa/crd:OkresFaKorygowanej">
                         <fo:block text-align="left" space-after="2mm">
                             <fo:inline font-weight="bold" font-size="12pt">
                                 <xsl:choose>
@@ -1034,54 +1034,21 @@
                                 </xsl:if>
                             </xsl:when>
                             <xsl:otherwise>
-                                <xsl:choose>
-                                    <xsl:when test="local:norm(crd:Fa/crd:RodzajFaktury) = 'ZAL' or local:norm(crd:Fa/crd:RodzajFaktury) = 'KOR_ZAL'">
-                                        <!-- ZAL can have both Zamówienie and FaWiersz: show both sections in order: Pozycje first, then Zamówienie -->
-                                        <xsl:if test="crd:Fa/crd:FaWiersz">
-                                            <fo:block text-align="left" space-after="2mm" space-before="2mm">
-                                                <fo:inline font-weight="bold" font-size="12pt"><xsl:value-of select="key('kLabels', 'positions', $labels)"/></fo:inline>
-                                            </fo:block>
-                                            <xsl:call-template name="positionsTable">
-                                                <xsl:with-param name="faWiersz" select="crd:Fa/crd:FaWiersz"/>
-                                            </xsl:call-template>
-                                        </xsl:if>
-                                        <xsl:if test="crd:Fa/crd:Zamowienie/crd:ZamowienieWiersz or crd:Fa/crd:Zamowienie/crd:WartoscZamowienia">
-                                            <fo:block text-align="left" space-after="2mm" space-before="2mm">
-                                                <fo:inline font-weight="bold" font-size="12pt"><xsl:value-of select="key('kLabels', 'order', $labels)"/></fo:inline>
-                                            </fo:block>
-                                            <xsl:if test="crd:Fa/crd:Zamowienie/crd:WartoscZamowienia">
-                                                <fo:block font-size="8pt" font-weight="bold" text-align="left" space-before="1mm" space-after="3mm">
-                                                    <fo:inline><xsl:value-of select="key('kLabels', 'orderValueWithTax', $labels)"/>: </fo:inline>
-                                                    <fo:inline>
-                                                        <xsl:value-of select="local:format-amount(crd:Fa/crd:Zamowienie/crd:WartoscZamowienia)"/>
-                                                        <xsl:text> </xsl:text>
-                                                        <xsl:value-of select="crd:Fa/crd:KodWaluty"/>
-                                                    </fo:inline>
-                                                </fo:block>
-                                            </xsl:if>
-                                            <xsl:if test="crd:Fa/crd:Zamowienie/crd:ZamowienieWiersz">
-                                                <xsl:call-template name="zamowienieTable">
-                                                    <xsl:with-param name="zamowienieWiersz" select="crd:Fa/crd:Zamowienie/crd:ZamowienieWiersz"/>
-                                                </xsl:call-template>
-                                            </xsl:if>
-                                        </xsl:if>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <!-- Show positions table only if there are invoice lines -->
-                                        <xsl:if test="crd:Fa/crd:FaWiersz">
-                                            <xsl:call-template name="positionsTable">
-                                                <xsl:with-param name="faWiersz" select="crd:Fa/crd:FaWiersz"/>
-                                            </xsl:call-template>
-                                        </xsl:if>
-                                    </xsl:otherwise>
-                                </xsl:choose>
+                                <!-- Show positions table only if there are invoice lines -->
+                                <xsl:if test="crd:Fa/crd:FaWiersz">
+                                    <xsl:call-template name="positionsTable">
+                                        <xsl:with-param name="faWiersz" select="crd:Fa/crd:FaWiersz"/>
+                                    </xsl:call-template>
+                                </xsl:if>
                             </xsl:otherwise>
                         </xsl:choose>
+                        <!-- Order section: rendered after positions for every invoice type and correction state (no-op when no Zamowienie present) -->
+                        <xsl:apply-templates select="crd:Fa/crd:Zamowienie"/>
                         </fo:block>
                     </xsl:if>
 
                     <!-- Show amounts section only if there are invoice lines or orders -->
-                    <xsl:if test="crd:Fa/crd:FaWiersz or crd:Fa/crd:Zamowienie/crd:ZamowienieWiersz or crd:Fa/crd:OkresFaKorygowanej">
+                    <xsl:if test="crd:Fa/crd:FaWiersz or crd:Fa/crd:Zamowienie or crd:Fa/crd:OkresFaKorygowanej">
                         <!-- Kwota należności ogółem -->
 
                         <!-- Conditional block for displaying correction amounts only when RodzajFaktury = 'KOR' -->

--- a/src/main/resources/templates/fa3/order-invoice-rows.xsl
+++ b/src/main/resources/templates/fa3/order-invoice-rows.xsl
@@ -23,41 +23,29 @@
         <xsl:attribute name="padding-bottom">4pt</xsl:attribute>
     </xsl:attribute-set>
 
-    <!-- Template for rendering the order table -->
+    <!-- Template for rendering one set of order rows. The before/after correction split
+         (StanPrzedZ) is decided by the caller, so this table has no "Stan przed" column. -->
     <xsl:template name="zamowienieTable">
         <xsl:param name="zamowienieWiersz"/>
-        <xsl:param name="faWierszBefore" select="()"/>
-        <xsl:param name="faWierszAfter" select="()"/>
 
         <!-- Only output table when there is at least one row (avoids empty fo:table-body which is invalid in XSL-FO) -->
-        <xsl:if test="($faWierszBefore and $faWierszAfter) or $zamowienieWiersz">
+        <xsl:if test="$zamowienieWiersz">
         <!-- Check if columns should be displayed -->
         <xsl:variable name="showP9AZ" select="boolean($zamowienieWiersz[crd:P_9AZ])"/>
         <xsl:variable name="showP11NettoZ" select="boolean($zamowienieWiersz[crd:P_11NettoZ])"/>
         <xsl:variable name="showP11VatZ" select="boolean($zamowienieWiersz[crd:P_11VatZ])"/>
         <xsl:variable name="showUU_IDZ" select="boolean($zamowienieWiersz[crd:UU_IDZ])"/>
-        
-        <!-- Check if any record has StanPrzedZ value -->
-        <xsl:variable name="showStanPrzed" select="boolean($zamowienieWiersz[crd:StanPrzedZ])"/>
 
         <!-- Calculate column width for name based on presence of other columns -->
         <xsl:variable name="nameColumnWidth">
             <xsl:choose>
-                <xsl:when test="$showP11VatZ and $showP9AZ and $showUU_IDZ and $showStanPrzed">16%</xsl:when>
-                <xsl:when test="$showP11VatZ and $showP9AZ and $showUU_IDZ and not($showStanPrzed)">22%</xsl:when>
-                <xsl:when test="$showP11VatZ and not($showP9AZ) and $showUU_IDZ and $showStanPrzed">24%</xsl:when>
-                <xsl:when test="$showP11VatZ and not($showP9AZ) and $showUU_IDZ and not($showStanPrzed)">32%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and $showP9AZ and $showUU_IDZ and $showStanPrzed">22%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and $showP9AZ and $showUU_IDZ and not($showStanPrzed)">29%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and not($showP9AZ) and $showUU_IDZ and $showStanPrzed">30%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and not($showP9AZ) and $showUU_IDZ and not($showStanPrzed)">39%</xsl:when>
-                <xsl:when test="$showP11VatZ and $showP9AZ and not($showUU_IDZ) and $showStanPrzed">28%</xsl:when>
-                <xsl:when test="$showP11VatZ and $showP9AZ and not($showUU_IDZ) and not($showStanPrzed)">36%</xsl:when>
-                <xsl:when test="$showP11VatZ and not($showP9AZ) and not($showUU_IDZ) and $showStanPrzed">36%</xsl:when>
-                <xsl:when test="$showP11VatZ and not($showP9AZ) and not($showUU_IDZ) and not($showStanPrzed)">46%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and $showP9AZ and not($showUU_IDZ) and $showStanPrzed">34%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and $showP9AZ and not($showUU_IDZ) and not($showStanPrzed)">44%</xsl:when>
-                <xsl:when test="not($showP11VatZ) and not($showP9AZ) and not($showUU_IDZ) and $showStanPrzed">44%</xsl:when>
+                <xsl:when test="$showP11VatZ and $showP9AZ and $showUU_IDZ">22%</xsl:when>
+                <xsl:when test="$showP11VatZ and not($showP9AZ) and $showUU_IDZ">32%</xsl:when>
+                <xsl:when test="not($showP11VatZ) and $showP9AZ and $showUU_IDZ">29%</xsl:when>
+                <xsl:when test="not($showP11VatZ) and not($showP9AZ) and $showUU_IDZ">39%</xsl:when>
+                <xsl:when test="$showP11VatZ and $showP9AZ and not($showUU_IDZ)">36%</xsl:when>
+                <xsl:when test="$showP11VatZ and not($showP9AZ) and not($showUU_IDZ)">46%</xsl:when>
+                <xsl:when test="not($showP11VatZ) and $showP9AZ and not($showUU_IDZ)">44%</xsl:when>
                 <xsl:otherwise>54%</xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
@@ -81,9 +69,6 @@
             </xsl:if>
             <xsl:if test="$showP11VatZ">
                 <fo:table-column column-width="10%"/> <!-- Kwota VAT -->
-            </xsl:if>
-            <xsl:if test="$showStanPrzed">
-                <fo:table-column column-width="8%"/> <!-- Stan przed -->
             </xsl:if>
 
             <!-- Table header -->
@@ -124,319 +109,138 @@
                             <fo:block><xsl:value-of select="key('kLabels', 'row.vatAmount', $labels)"/></fo:block>
                         </fo:table-cell>
                     </xsl:if>
-                    <xsl:if test="$showStanPrzed">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.stateBefore', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
                 </fo:table-row>
             </fo:table-header>
 
             <!-- Table body -->
             <fo:table-body>
-                <xsl:choose>
-                    <xsl:when test="$faWierszBefore and $faWierszAfter">
-                        <!-- Differences mode -->
-                        <xsl:call-template name="zaliczkoweDifferencesTable">
-                            <xsl:with-param name="faWierszBefore" select="$faWierszBefore"/>
-                            <xsl:with-param name="faWierszAfter" select="$faWierszAfter"/>
-                        </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <!-- Normal mode -->
-                        <xsl:for-each select="$zamowienieWiersz">
-                            <fo:table-row >
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                                    <fo:block>
-                                        <xsl:value-of select="crd:NrWierszaZam"/>
+                <xsl:for-each select="$zamowienieWiersz">
+                    <fo:table-row>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
+                            <fo:block>
+                                <xsl:value-of select="crd:NrWierszaZam"/>
+                            </fo:block>
+                        </fo:table-cell>
+                        <xsl:if test="$showUU_IDZ">
+                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
+                                <fo:block wrap-option="wrap" white-space-collapse="false" hyphenation-character="-" hyphenation-push-character-count="2" hyphenation-remain-character-count="2">
+                                    <xsl:value-of select="crd:UU_IDZ"/>
+                                </fo:block>
+                            </fo:table-cell>
+                        </xsl:if>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
+                            <fo:block>
+                                <xsl:value-of select="crd:P_7Z"/>
+                            </fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                            <xsl:variable name="formattedQty" select="translate(format-number(number(crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
+                            <xsl:variable name="qtyLength" select="string-length($formattedQty)"/>
+                            <xsl:choose>
+                                <xsl:when test="$qtyLength &gt; 14">
+                                    <fo:block font-size="5pt">
+                                        <xsl:value-of select="$formattedQty"/>
                                     </fo:block>
-                                </fo:table-cell>
-                                <xsl:if test="$showUU_IDZ">
-                                    <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                                        <fo:block wrap-option="wrap" white-space-collapse="false" hyphenation-character="-" hyphenation-push-character-count="2" hyphenation-remain-character-count="2">
-                                            <xsl:value-of select="crd:UU_IDZ"/>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </xsl:if>
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                                    <fo:block>
-                                        <xsl:value-of select="crd:P_7Z"/>
+                                </xsl:when>
+                                <xsl:when test="$qtyLength &gt; 10">
+                                    <fo:block font-size="6pt">
+                                        <xsl:value-of select="$formattedQty"/>
                                     </fo:block>
-                                </fo:table-cell>
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <xsl:variable name="formattedQty" select="translate(format-number(number(crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
-                                    <xsl:variable name="qtyLength" select="string-length($formattedQty)"/>
-                                    <xsl:choose>
-                                        <xsl:when test="$qtyLength &gt; 14">
-                                            <fo:block font-size="5pt">
-                                                <xsl:value-of select="$formattedQty"/>
-                                            </fo:block>
-                                        </xsl:when>
-                                        <xsl:when test="$qtyLength &gt; 10">
-                                            <fo:block font-size="6pt">
-                                                <xsl:value-of select="$formattedQty"/>
-                                            </fo:block>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <fo:block>
-                                                <xsl:value-of select="$formattedQty"/>
-                                            </fo:block>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </fo:table-cell>
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                                </xsl:when>
+                                <xsl:otherwise>
                                     <fo:block>
-                                        <xsl:value-of select="crd:P_8AZ"/>
+                                        <xsl:value-of select="$formattedQty"/>
                                     </fo:block>
-                                </fo:table-cell>
-                                <xsl:if test="$showP9AZ">
-                                    <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                        <fo:block>
-                                            <xsl:if test="crd:P_9AZ">
-                                                <xsl:value-of select="translate(format-number(number(crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
-                                            </xsl:if>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </xsl:if>
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="taxRate" select="crd:P_12Z"/>
-                                        <xsl:choose>
-                                            <xsl:when test="number($taxRate) = $taxRate and $taxRate != ''">
-                                                <xsl:value-of select="$taxRate"/>%
-                                            </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$taxRate"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                                <xsl:if test="$showP11NettoZ">
-                                    <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                        <fo:block>
-                                            <xsl:if test="crd:P_11NettoZ">
-                                                <xsl:value-of select="translate(format-number(number(crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
-                                            </xsl:if>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </xsl:if>
-                                <xsl:if test="$showP11VatZ">
-                                    <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                        <fo:block>
-                                            <xsl:if test="crd:P_11VatZ">
-                                                <xsl:value-of select="translate(format-number(number(crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
-                                            </xsl:if>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </xsl:if>
-                                <xsl:if test="$showStanPrzed">
-                                    <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                                        <fo:block>
-                                            <xsl:if test="crd:StanPrzedZ = '1'">
-                                                <xsl:value-of select="key('kLabels', 'common.yes', $labels)"/>
-                                            </xsl:if>
-                                        </fo:block>
-                                    </fo:table-cell>
-                                </xsl:if>
-                            </fo:table-row>
-                        </xsl:for-each>
-                    </xsl:otherwise>
-                </xsl:choose>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </fo:table-cell>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                            <fo:block>
+                                <xsl:value-of select="crd:P_8AZ"/>
+                            </fo:block>
+                        </fo:table-cell>
+                        <xsl:if test="$showP9AZ">
+                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                                <fo:block>
+                                    <xsl:if test="crd:P_9AZ">
+                                        <xsl:value-of select="translate(format-number(number(crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
+                                    </xsl:if>
+                                </fo:block>
+                            </fo:table-cell>
+                        </xsl:if>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                            <fo:block>
+                                <xsl:variable name="taxRate" select="crd:P_12Z"/>
+                                <xsl:choose>
+                                    <xsl:when test="number($taxRate) = $taxRate and $taxRate != ''">
+                                        <xsl:value-of select="$taxRate"/>%
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="$taxRate"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </fo:block>
+                        </fo:table-cell>
+                        <xsl:if test="$showP11NettoZ">
+                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                                <fo:block>
+                                    <xsl:if test="crd:P_11NettoZ">
+                                        <xsl:value-of select="translate(format-number(number(crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
+                                    </xsl:if>
+                                </fo:block>
+                            </fo:table-cell>
+                        </xsl:if>
+                        <xsl:if test="$showP11VatZ">
+                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                                <fo:block>
+                                    <xsl:if test="crd:P_11VatZ">
+                                        <xsl:value-of select="translate(format-number(number(crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
+                                    </xsl:if>
+                                </fo:block>
+                            </fo:table-cell>
+                        </xsl:if>
+                    </fo:table-row>
+                </xsl:for-each>
             </fo:table-body>
         </fo:table>
         </xsl:if>
     </xsl:template>
 
-    <!-- Template for order positions -->
-    <xsl:template match="crd:ZamowienieWiersz" mode="zamowienie">
-        <fo:table-row>
-            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="left">
-                <fo:block>
-                    <xsl:value-of select="crd:NrWierszaZam"/>
-                </fo:block>
-            </fo:table-cell>
-            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" padding-left="3pt">
-                <fo:block>
-                    <xsl:value-of select="crd:P_7Z"/>
-                </fo:block>
-            </fo:table-cell>
-            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                <xsl:variable name="formattedQty" select="translate(format-number(number(crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
-                <xsl:variable name="qtyLength" select="string-length($formattedQty)"/>
-                <xsl:choose>
-                    <xsl:when test="$qtyLength &gt; 14">
-                        <fo:block font-size="5pt">
-                            <xsl:value-of select="$formattedQty"/>
-                        </fo:block>
-                    </xsl:when>
-                    <xsl:when test="$qtyLength &gt; 10">
-                        <fo:block font-size="6pt">
-                            <xsl:value-of select="$formattedQty"/>
-                        </fo:block>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <fo:block>
-                            <xsl:value-of select="$formattedQty"/>
-                        </fo:block>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </fo:table-cell>
-            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                <fo:block>
-                    <xsl:value-of select="crd:P_8AZ"/>
-                </fo:block>
-            </fo:table-cell>
-            <xsl:if test="//crd:ZamowienieWiersz/crd:P_9AZ">
-                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                    <fo:block>
-                        <xsl:choose>
-                            <xsl:when test="crd:P_9AZ">
-                                <xsl:variable name="formattedNumber">
-                                    <xsl:value-of select="translate(format-number(number(crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
-                                </xsl:variable>
-                                <xsl:choose>
-                                    <xsl:when test="string-length($formattedNumber) > 8">
-                                        <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:value-of select="$formattedNumber"/>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <fo:block/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </fo:block>
-                </fo:table-cell>
-            </xsl:if>
-            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                <fo:block>
-                    <xsl:variable name="taxRate" select="crd:P_12Z"/>
-                    <xsl:choose>
-                        <xsl:when test="number($taxRate) = $taxRate and $taxRate != ''">
-                            <xsl:value-of select="$taxRate"/>%
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="$taxRate"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </fo:block>
-            </fo:table-cell>
-            <xsl:if test="//crd:ZamowienieWiersz/crd:P_11NettoZ">
-                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                    <fo:block>
-                        <xsl:choose>
-                            <xsl:when test="crd:P_11NettoZ">
-                                <xsl:variable name="formattedNumber" select="translate(format-number(number(crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
-                                <xsl:choose>
-                                    <xsl:when test="string-length($formattedNumber) > 8">
-                                        <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:value-of select="$formattedNumber"/>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <fo:block/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </fo:block>
-                </fo:table-cell>
-            </xsl:if>
-            <xsl:if test="//crd:ZamowienieWiersz/crd:P_11VatZ">
-                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                    <fo:block>
-                        <xsl:choose>
-                            <xsl:when test="crd:P_11VatZ">
-                                <xsl:variable name="formattedNumber" select="translate(format-number(number(crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
-                                <xsl:choose>
-                                    <xsl:when test="string-length($formattedNumber) > 8">
-                                        <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:value-of select="$formattedNumber"/>
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <fo:block/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </fo:block>
-                </fo:table-cell>
-            </xsl:if>
-            <xsl:if test="//crd:ZamowienieWiersz/crd:StanPrzedZ">
-                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="center">
-                    <fo:block>
-                        <xsl:if test="crd:StanPrzedZ = '1'">
-                            <xsl:value-of select="key('kLabels', 'common.yes', $labels)"/>
-                        </xsl:if>
-                    </fo:block>
-                </fo:table-cell>
-            </xsl:if>
-        </fo:table-row>
-    </xsl:template>
+    <!-- Differences table for order rows: shows after-minus-before per NrWierszaZam,
+         mirroring differencesTable but on the Z-suffixed order fields. -->
+    <xsl:template name="zamowienieDifferencesTable">
+        <xsl:param name="zamowienieWierszBefore"/>
+        <xsl:param name="zamowienieWierszAfter"/>
 
-    <xsl:template name="zaliczkoweDifferencesTable">
-        <xsl:param name="faWierszBefore"/>
-        <xsl:param name="faWierszAfter"/>
+        <xsl:variable name="showP9AZ" select="boolean($zamowienieWierszAfter[crd:P_9AZ])"/>
+        <xsl:variable name="showP11NettoZ" select="boolean($zamowienieWierszAfter[crd:P_11NettoZ])"/>
+        <xsl:variable name="showP11VatZ" select="boolean($zamowienieWierszAfter[crd:P_11VatZ])"/>
 
         <xsl:variable name="nameColumnWidth">
             <xsl:choose>
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and $faWierszAfter/crd:P_11A and $faWierszAfter/crd:P_9B and $faWierszAfter/crd:P_10">22%</xsl:when>
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and $faWierszAfter/crd:P_11A and $faWierszAfter/crd:P_9B and not($faWierszAfter/crd:P_10)">29%</xsl:when>
-                
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and $faWierszAfter/crd:P_11A and not($faWierszAfter/crd:P_9B) and $faWierszAfter/crd:P_10">31%</xsl:when>
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and $faWierszAfter/crd:P_11A and not($faWierszAfter/crd:P_9B) and not($faWierszAfter/crd:P_10)">38%</xsl:when>
-                
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and not($faWierszAfter/crd:P_11A) and $faWierszAfter/crd:P_9B and $faWierszAfter/crd:P_10">32%</xsl:when>
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and not($faWierszAfter/crd:P_11A) and $faWierszAfter/crd:P_9B and not($faWierszAfter/crd:P_10)">39%</xsl:when>
-                
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and not($faWierszAfter/crd:P_11A) and not($faWierszAfter/crd:P_9B) and $faWierszAfter/crd:P_10">41%</xsl:when>
-                <xsl:when test="$faWierszAfter/crd:P_11Vat and not($faWierszAfter/crd:P_11A) and not($faWierszAfter/crd:P_9B) and not($faWierszAfter/crd:P_10)">48%</xsl:when>
-                
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and $faWierszAfter/crd:P_11A and $faWierszAfter/crd:P_9B and $faWierszAfter/crd:P_10">29%</xsl:when>
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and $faWierszAfter/crd:P_11A and $faWierszAfter/crd:P_9B and not($faWierszAfter/crd:P_10)">36%</xsl:when>
-                
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and $faWierszAfter/crd:P_11A and not($faWierszAfter/crd:P_9B) and $faWierszAfter/crd:P_10">38%</xsl:when>
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and $faWierszAfter/crd:P_11A and not($faWierszAfter/crd:P_9B) and not($faWierszAfter/crd:P_10)">45%</xsl:when>
-                
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and not($faWierszAfter/crd:P_11A) and $faWierszAfter/crd:P_9B and $faWierszAfter/crd:P_10">39%</xsl:when>
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and not($faWierszAfter/crd:P_11A) and $faWierszAfter/crd:P_9B and not($faWierszAfter/crd:P_10)">46%</xsl:when>
-                
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and not($faWierszAfter/crd:P_11A) and not($faWierszAfter/crd:P_9B) and $faWierszAfter/crd:P_10">48%</xsl:when>
-                <xsl:when test="not($faWierszAfter/crd:P_11Vat) and not($faWierszAfter/crd:P_11A) and not($faWierszAfter/crd:P_9B) and not($faWierszAfter/crd:P_10)">55%</xsl:when>
+                <xsl:when test="$showP11VatZ and $showP9AZ">36%</xsl:when>
+                <xsl:when test="$showP11VatZ and not($showP9AZ)">46%</xsl:when>
+                <xsl:when test="not($showP11VatZ) and $showP9AZ">44%</xsl:when>
+                <xsl:otherwise>54%</xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
 
         <fo:table table-layout="fixed" width="100%" border-collapse="separate" space-after="5mm">
             <fo:table-column column-width="4%"/> <!-- Lp. -->
-            <fo:table-column column-width="{$nameColumnWidth}"/> <!-- Nazwa - dynamiczna szerokość -->
-            <fo:table-column column-width="10%"/> <!-- Ilość -->
-            <fo:table-column column-width="5%"/> <!-- Jednostka -->
-            <xsl:if test="$faWierszAfter/crd:P_9A">
-                <fo:table-column column-width="10%"/> <!-- Cena jednostkowa netto -->
-            </xsl:if>
-            <xsl:if test="$faWierszAfter/crd:P_9B">
-                <fo:table-column column-width="10%"/> <!-- Cena jednostkowa brutto -->
-            </xsl:if>
-            <xsl:if test="$faWierszAfter/crd:P_10">
-                <fo:table-column column-width="7%"/> <!-- Rabat -->
+            <fo:table-column column-width="{$nameColumnWidth}"/> <!-- Nazwa -->
+            <fo:table-column column-width="12%"/> <!-- Ilość -->
+            <fo:table-column column-width="6%"/> <!-- Jednostka -->
+            <xsl:if test="$showP9AZ">
+                <fo:table-column column-width="12%"/> <!-- Cena jednostkowa netto -->
             </xsl:if>
             <fo:table-column column-width="8%"/> <!-- Stawka podatku -->
-            <xsl:if test="$faWierszAfter/crd:P_11">
-                <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży netto-->
+            <xsl:if test="$showP11NettoZ">
+                <fo:table-column column-width="12%"/> <!-- Wartość netto -->
             </xsl:if>
-            <xsl:if test="$faWierszAfter/crd:P_11Vat">
-                <fo:table-column column-width="7%"/> <!-- Kwota VAT-->
-            </xsl:if>
-            <xsl:if test="$faWierszAfter/crd:P_11A">
-                <fo:table-column column-width="10%"/> <!-- Wartość sprzedaży brutto-->
+            <xsl:if test="$showP11VatZ">
+                <fo:table-column column-width="10%"/> <!-- Kwota VAT -->
             </xsl:if>
 
-            <!-- Table header - identical to positionsTable -->
             <fo:table-header>
                 <fo:table-row background-color="#f5f5f5" font-weight="bold">
                     <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
@@ -451,325 +255,195 @@
                     <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
                         <fo:block><xsl:value-of select="key('kLabels', 'row.unit', $labels)"/></fo:block>
                     </fo:table-cell>
-                    <xsl:if test="$faWierszAfter/crd:P_9A">
+                    <xsl:if test="$showP9AZ">
                         <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
                             <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceNet', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWierszAfter/crd:P_9B">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.unitPriceGross', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWierszAfter/crd:P_10">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.discount', $labels)"/></fo:block>
                         </fo:table-cell>
                     </xsl:if>
                     <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
                         <fo:block><xsl:value-of select="key('kLabels', 'row.taxRate', $labels)"/></fo:block>
                     </fo:table-cell>
-                    <xsl:if test="$faWierszAfter/crd:P_11">
+                    <xsl:if test="$showP11NettoZ">
                         <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.netValue', $labels)"/></fo:block>
+                            <fo:block><xsl:value-of select="key('kLabels', 'row.netValueShort', $labels)"/></fo:block>
                         </fo:table-cell>
                     </xsl:if>
-                    <xsl:if test="$faWierszAfter/crd:P_11Vat">
+                    <xsl:if test="$showP11VatZ">
                         <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
                             <fo:block><xsl:value-of select="key('kLabels', 'row.vatAmount', $labels)"/></fo:block>
-                        </fo:table-cell>
-                    </xsl:if>
-                    <xsl:if test="$faWierszAfter/crd:P_11A">
-                        <fo:table-cell xsl:use-attribute-sets="tableHeaderFont tableBorder table.cell.padding">
-                            <fo:block><xsl:value-of select="key('kLabels', 'row.grossValue', $labels)"/></fo:block>
                         </fo:table-cell>
                     </xsl:if>
                 </fo:table-row>
             </fo:table-header>
 
-            <!-- Table body -->
             <fo:table-body>
-                <!-- Process each row to calculate and show differences -->
-                <xsl:for-each select="$faWierszAfter">
-                    <xsl:variable name="lineNum" select="crd:NrWierszaFa"/>
+                <xsl:for-each select="$zamowienieWierszAfter">
+                    <xsl:variable name="lineNum" select="crd:NrWierszaZam"/>
                     <xsl:variable name="after" select="."/>
-                    <xsl:variable name="before" select="$faWierszBefore[crd:NrWierszaFa = $lineNum]"/>
-                    
-                    <!-- New flag to determine if this is a new row not in "before" -->
+                    <xsl:variable name="before" select="$zamowienieWierszBefore[crd:NrWierszaZam = $lineNum]"/>
                     <xsl:variable name="isNewRow" select="not($before)"/>
-                        <fo:table-row>
-                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
-                                <fo:block><xsl:value-of select="$lineNum"/></fo:block>
-                            </fo:table-cell>
-                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
-                                <fo:block><xsl:value-of select="$after/crd:P_7"/></fo:block>
-                            </fo:table-cell>
-                            
-                            <!-- Quantity - for new rows, show exact "after" value, otherwise show difference -->
-                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                <xsl:variable name="formattedQty">
-                                    <xsl:choose>
-                                        <xsl:when test="$isNewRow">
-                                            <xsl:value-of select="translate(format-number(number($after/crd:P_8B), '#,##0.######'), '.,', ',&#160;')"/>
-                                        </xsl:when>
-                                        <xsl:when test="$before/crd:P_8B and $after/crd:P_8B">
-                                            <xsl:value-of select="translate(format-number(number($after/crd:P_8B) - number($before/crd:P_8B), '#,##0.######'), '.,', ',&#160;')"/>
-                                        </xsl:when>
-                                        <xsl:when test="not($before/crd:P_8B) and $after/crd:P_8B">
-                                            <xsl:value-of select="translate(format-number(number($after/crd:P_8B), '#,##0.######'), '.,', ',&#160;')"/>
-                                        </xsl:when>
-                                        <xsl:when test="$before/crd:P_8B and not($after/crd:P_8B)">
-                                            <xsl:value-of select="translate(format-number(-number($before/crd:P_8B), '#,##0.######'), '.,', ',&#160;')"/>
-                                        </xsl:when>
-                                        <xsl:otherwise>0</xsl:otherwise>
-                                    </xsl:choose>
-                                </xsl:variable>
-                                <xsl:variable name="qtyLength" select="string-length($formattedQty)"/>
+                    <fo:table-row>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
+                            <fo:block><xsl:value-of select="$lineNum"/></fo:block>
+                        </fo:table-cell>
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding">
+                            <fo:block><xsl:value-of select="$after/crd:P_7Z"/></fo:block>
+                        </fo:table-cell>
+
+                        <!-- Quantity difference -->
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                            <xsl:variable name="formattedQty">
                                 <xsl:choose>
-                                    <xsl:when test="$qtyLength &gt; 14">
-                                        <fo:block font-size="5pt">
-                                            <xsl:value-of select="$formattedQty"/>
-                                        </fo:block>
+                                    <xsl:when test="$isNewRow">
+                                        <xsl:value-of select="translate(format-number(number($after/crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
                                     </xsl:when>
-                                    <xsl:when test="$qtyLength &gt; 10">
-                                        <fo:block font-size="6pt">
-                                            <xsl:value-of select="$formattedQty"/>
-                                        </fo:block>
+                                    <xsl:when test="$before/crd:P_8BZ and $after/crd:P_8BZ">
+                                        <xsl:value-of select="translate(format-number(number($after/crd:P_8BZ) - number($before/crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
                                     </xsl:when>
-                                    <xsl:otherwise>
-                                        <fo:block>
-                                            <xsl:value-of select="$formattedQty"/>
-                                        </fo:block>
-                                    </xsl:otherwise>
+                                    <xsl:when test="not($before/crd:P_8BZ) and $after/crd:P_8BZ">
+                                        <xsl:value-of select="translate(format-number(number($after/crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
+                                    </xsl:when>
+                                    <xsl:when test="$before/crd:P_8BZ and not($after/crd:P_8BZ)">
+                                        <xsl:value-of select="translate(format-number(-number($before/crd:P_8BZ), '#,##0.######'), '.,', ',&#160;')"/>
+                                    </xsl:when>
+                                    <xsl:otherwise>0</xsl:otherwise>
                                 </xsl:choose>
-                            </fo:table-cell>
-                            
-                            <!-- Unit - show only "after" value -->
+                            </xsl:variable>
+                            <xsl:variable name="qtyLength" select="string-length($formattedQty)"/>
+                            <xsl:choose>
+                                <xsl:when test="$qtyLength &gt; 14">
+                                    <fo:block font-size="5pt"><xsl:value-of select="$formattedQty"/></fo:block>
+                                </xsl:when>
+                                <xsl:when test="$qtyLength &gt; 10">
+                                    <fo:block font-size="6pt"><xsl:value-of select="$formattedQty"/></fo:block>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <fo:block><xsl:value-of select="$formattedQty"/></fo:block>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </fo:table-cell>
+
+                        <!-- Unit - show only "after" value -->
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                            <fo:block>
+                                <xsl:value-of select="$after/crd:P_8AZ"/>
+                            </fo:block>
+                        </fo:table-cell>
+
+                        <!-- Net unit price difference -->
+                        <xsl:if test="$showP9AZ">
                             <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
                                 <fo:block>
-                                    <xsl:value-of select="$after/crd:P_8A"/>
-                                </fo:block>
-                            </fo:table-cell>
-                            
-                            <!-- Net unit price difference with font-size adjustment -->
-                            <xsl:if test="$faWierszAfter/crd:P_9A">
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="formattedNumber">
-                                            <xsl:choose>
-                                                <xsl:when test="$isNewRow and $after/crd:P_9A">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_9A), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_9A and $after/crd:P_9A and $before/crd:P_9A != $after/crd:P_9A">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_9A) - number($before/crd:P_9A), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="not($before/crd:P_9A) and $after/crd:P_9A">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_9A), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_9A and not($after/crd:P_9A)">
-                                                    <xsl:value-of select="translate(format-number(-number($before/crd:P_9A), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>0,00</xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:variable>
-                                        
+                                    <xsl:variable name="formattedNumber">
                                         <xsl:choose>
-                                            <xsl:when test="string-length($formattedNumber) > 8">
-                                                <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                            <xsl:when test="$isNewRow and $after/crd:P_9AZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$formattedNumber"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </xsl:if>
-                            
-                            <!-- Gross unit price difference with font-size adjustment -->
-                            <xsl:if test="$faWierszAfter/crd:P_9B">
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="formattedNumber">
-                                            <xsl:choose>
-                                                <xsl:when test="$isNewRow and $after/crd:P_9B">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_9B), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_9B and $after/crd:P_9B and $before/crd:P_9B != $after/crd:P_9B">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_9B) - number($before/crd:P_9B), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="not($before/crd:P_9B) and $after/crd:P_9B">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_9B), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_9B and not($after/crd:P_9B)">
-                                                    <xsl:value-of select="translate(format-number(-number($before/crd:P_9B), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>0,00</xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:variable>
-                                        
-                                        <xsl:choose>
-                                            <xsl:when test="string-length($formattedNumber) > 8">
-                                                <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                            <xsl:when test="$before/crd:P_9AZ and $after/crd:P_9AZ and $before/crd:P_9AZ != $after/crd:P_9AZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_9AZ) - number($before/crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$formattedNumber"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </xsl:if>
-                            
-                            <!-- Discount difference with font-size adjustment -->
-                            <xsl:if test="$faWierszAfter/crd:P_10">
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="formattedNumber">
-                                            <xsl:choose>
-                                                <xsl:when test="$isNewRow and $after/crd:P_10">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_10), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_10 and $after/crd:P_10 and $before/crd:P_10 != $after/crd:P_10">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_10) - number($before/crd:P_10), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="not($before/crd:P_10) and $after/crd:P_10">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_10), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_10 and not($after/crd:P_10)">
-                                                    <xsl:value-of select="translate(format-number(-number($before/crd:P_10), '#,##0.########'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>0,00</xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:variable>
-                                        
-                                        <xsl:choose>
-                                            <xsl:when test="string-length($formattedNumber) > 8">
-                                                <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                            <xsl:when test="not($before/crd:P_9AZ) and $after/crd:P_9AZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$formattedNumber"/>
-                                            </xsl:otherwise>
+                                            <xsl:when test="$before/crd:P_9AZ and not($after/crd:P_9AZ)">
+                                                <xsl:value-of select="translate(format-number(-number($before/crd:P_9AZ), '#,##0.########'), ',.', ' ,')"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>0,00</xsl:otherwise>
                                         </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </xsl:if>
-                            
-                            <!-- Tax rate - show only "after" value -->
-                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                <fo:block>
-                                    <xsl:variable name="taxRate" select="$after/crd:P_12"/>
+                                    </xsl:variable>
                                     <xsl:choose>
-                                        <xsl:when test="number($taxRate) = $taxRate and $taxRate != ''">
-                                            <xsl:value-of select="$taxRate"/>%
+                                        <xsl:when test="string-length($formattedNumber) > 8">
+                                            <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
                                         </xsl:when>
                                         <xsl:otherwise>
-                                            <xsl:value-of select="$taxRate"/>
+                                            <xsl:value-of select="$formattedNumber"/>
                                         </xsl:otherwise>
                                     </xsl:choose>
                                 </fo:block>
                             </fo:table-cell>
-                            
-                            <!-- Net value difference with font-size adjustment -->
-                            <xsl:if test="$faWierszAfter/crd:P_11">
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="formattedNumber">
-                                            <xsl:choose>
-                                                <xsl:when test="$isNewRow and $after/crd:P_11">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_11 and $after/crd:P_11 and $before/crd:P_11 != $after/crd:P_11">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11) - number($before/crd:P_11), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="not($before/crd:P_11) and $after/crd:P_11">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_11 and not($after/crd:P_11)">
-                                                    <xsl:value-of select="translate(format-number(-number($before/crd:P_11), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>0,00</xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:variable>
-                                        
+                        </xsl:if>
+
+                        <!-- Tax rate - show only "after" value -->
+                        <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                            <fo:block>
+                                <xsl:variable name="taxRate" select="$after/crd:P_12Z"/>
+                                <xsl:choose>
+                                    <xsl:when test="number($taxRate) = $taxRate and $taxRate != ''">
+                                        <xsl:value-of select="$taxRate"/>%
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="$taxRate"/>
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </fo:block>
+                        </fo:table-cell>
+
+                        <!-- Net value difference -->
+                        <xsl:if test="$showP11NettoZ">
+                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                                <fo:block>
+                                    <xsl:variable name="formattedNumber">
                                         <xsl:choose>
-                                            <xsl:when test="string-length($formattedNumber) > 8">
-                                                <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                            <xsl:when test="$isNewRow and $after/crd:P_11NettoZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$formattedNumber"/>
-                                            </xsl:otherwise>
+                                            <xsl:when test="$before/crd:P_11NettoZ and $after/crd:P_11NettoZ and $before/crd:P_11NettoZ != $after/crd:P_11NettoZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_11NettoZ) - number($before/crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
+                                            </xsl:when>
+                                            <xsl:when test="not($before/crd:P_11NettoZ) and $after/crd:P_11NettoZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
+                                            </xsl:when>
+                                            <xsl:when test="$before/crd:P_11NettoZ and not($after/crd:P_11NettoZ)">
+                                                <xsl:value-of select="translate(format-number(-number($before/crd:P_11NettoZ), '#,##0.00'), ',.', ' ,')"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>0,00</xsl:otherwise>
                                         </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </xsl:if>
-                            
-                            <!-- VAT amount difference with font-size adjustment -->
-                            <xsl:if test="$faWierszAfter/crd:P_11Vat">
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="formattedNumber">
-                                            <xsl:choose>
-                                                <xsl:when test="$isNewRow and $after/crd:P_11Vat">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11Vat), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_11Vat and $after/crd:P_11Vat and $before/crd:P_11Vat != $after/crd:P_11Vat">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11Vat) - number($before/crd:P_11Vat), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="not($before/crd:P_11Vat) and $after/crd:P_11Vat">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11Vat), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_11Vat and not($after/crd:P_11Vat)">
-                                                    <xsl:value-of select="translate(format-number(-number($before/crd:P_11Vat), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>0,00</xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:variable>
-                                        
+                                    </xsl:variable>
+                                    <xsl:choose>
+                                        <xsl:when test="string-length($formattedNumber) > 8">
+                                            <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="$formattedNumber"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </fo:block>
+                            </fo:table-cell>
+                        </xsl:if>
+
+                        <!-- VAT amount difference -->
+                        <xsl:if test="$showP11VatZ">
+                            <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
+                                <fo:block>
+                                    <xsl:variable name="formattedNumber">
                                         <xsl:choose>
-                                            <xsl:when test="string-length($formattedNumber) > 8">
-                                                <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                            <xsl:when test="$isNewRow and $after/crd:P_11VatZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$formattedNumber"/>
-                                            </xsl:otherwise>
-                                        </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </xsl:if>
-                            
-                            <!-- Gross value difference with font-size adjustment -->
-                            <xsl:if test="$faWierszAfter/crd:P_11A">
-                                <fo:table-cell xsl:use-attribute-sets="tableFont tableBorder table.cell.padding" text-align="right">
-                                    <fo:block>
-                                        <xsl:variable name="formattedNumber">
-                                            <xsl:choose>
-                                                <xsl:when test="$isNewRow and $after/crd:P_11A">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11A), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_11A and $after/crd:P_11A and $before/crd:P_11A != $after/crd:P_11A">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11A) - number($before/crd:P_11A), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="not($before/crd:P_11A) and $after/crd:P_11A">
-                                                    <xsl:value-of select="translate(format-number(number($after/crd:P_11A), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:when test="$before/crd:P_11A and not($after/crd:P_11A)">
-                                                    <xsl:value-of select="translate(format-number(-number($before/crd:P_11A), '#,##0.00'), ',.', ' ,')"/>
-                                                </xsl:when>
-                                                <xsl:otherwise>0,00</xsl:otherwise>
-                                            </xsl:choose>
-                                        </xsl:variable>
-                                        
-                                        <xsl:choose>
-                                            <xsl:when test="string-length($formattedNumber) > 8">
-                                                <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                            <xsl:when test="$before/crd:P_11VatZ and $after/crd:P_11VatZ and $before/crd:P_11VatZ != $after/crd:P_11VatZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_11VatZ) - number($before/crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
                                             </xsl:when>
-                                            <xsl:otherwise>
-                                                <xsl:value-of select="$formattedNumber"/>
-                                            </xsl:otherwise>
+                                            <xsl:when test="not($before/crd:P_11VatZ) and $after/crd:P_11VatZ">
+                                                <xsl:value-of select="translate(format-number(number($after/crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
+                                            </xsl:when>
+                                            <xsl:when test="$before/crd:P_11VatZ and not($after/crd:P_11VatZ)">
+                                                <xsl:value-of select="translate(format-number(-number($before/crd:P_11VatZ), '#,##0.00'), ',.', ' ,')"/>
+                                            </xsl:when>
+                                            <xsl:otherwise>0,00</xsl:otherwise>
                                         </xsl:choose>
-                                    </fo:block>
-                                </fo:table-cell>
-                            </xsl:if>
-                        </fo:table-row>
+                                    </xsl:variable>
+                                    <xsl:choose>
+                                        <xsl:when test="string-length($formattedNumber) > 8">
+                                            <fo:inline font-size="6pt"><xsl:value-of select="$formattedNumber"/></fo:inline>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="$formattedNumber"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </fo:block>
+                            </fo:table-cell>
+                        </xsl:if>
+                    </fo:table-row>
                 </xsl:for-each>
             </fo:table-body>
         </fo:table>

--- a/src/main/resources/templates/fa3/order-invoice.xsl
+++ b/src/main/resources/templates/fa3/order-invoice.xsl
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format"
+                xmlns:crd="http://crd.gov.pl/wzor/2025/06/25/13775/"
+                xmlns:local="urn:local">
+
+    <!-- Note: $labels parameter, kLabels key and local: functions are defined in the main ksef_invoice.xsl -->
+
+    <!-- Row-level tables (zamowienieTable) live here; included so the order section is self-contained and overridable on its own. -->
+    <xsl:include href="order-invoice-rows.xsl"/>
+
+    <!--
+        Order ("Zamówienie") section.
+    -->
+    <xsl:template match="crd:Zamowienie">
+        <fo:block id="Zamowienie">
+            <!-- Section title -->
+            <fo:block text-align="left" space-after="2mm" space-before="2mm">
+                <fo:inline font-weight="bold" font-size="12pt"><xsl:value-of select="key('kLabels', 'order', $labels)"/></fo:inline>
+            </fo:block>
+
+            <!-- Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku -->
+            <xsl:if test="crd:WartoscZamowienia">
+                <fo:block font-size="8pt" font-weight="bold" text-align="left" space-before="1mm" space-after="3mm">
+                    <fo:inline><xsl:value-of select="key('kLabels', 'orderValueWithTax', $labels)"/>: </fo:inline>
+                    <fo:inline>
+                        <xsl:value-of select="local:format-amount(crd:WartoscZamowienia)"/>
+                        <xsl:text> </xsl:text>
+                        <xsl:value-of select="../crd:KodWaluty"/>
+                    </fo:inline>
+                </fo:block>
+            </xsl:if>
+
+            <!-- Order rows: mirror the FaWiersz before/after correction layout, keyed on StanPrzedZ -->
+            <xsl:choose>
+                <!-- Correction with both states: before, optional differences, after -->
+                <xsl:when test="crd:ZamowienieWiersz[crd:StanPrzedZ = 1] and crd:ZamowienieWiersz[not(crd:StanPrzedZ)]">
+                    <fo:block text-align="left" space-after="1mm">
+                        <fo:inline font-weight="bold" font-size="10pt"><xsl:value-of select="key('kLabels', 'orderBeforeCorrection', $labels)"/></fo:inline>
+                    </fo:block>
+                    <xsl:call-template name="zamowienieTable">
+                        <xsl:with-param name="zamowienieWiersz" select="crd:ZamowienieWiersz[crd:StanPrzedZ = 1]"/>
+                    </xsl:call-template>
+
+                    <xsl:if test="$showCorrectionDifferences">
+                        <fo:block text-align="left" space-after="1mm">
+                            <fo:inline font-weight="bold" font-size="10pt"><xsl:value-of select="key('kLabels', 'difference', $labels)"/></fo:inline>
+                        </fo:block>
+                        <xsl:call-template name="zamowienieDifferencesTable">
+                            <xsl:with-param name="zamowienieWierszBefore" select="crd:ZamowienieWiersz[crd:StanPrzedZ = 1]"/>
+                            <xsl:with-param name="zamowienieWierszAfter" select="crd:ZamowienieWiersz[not(crd:StanPrzedZ)]"/>
+                        </xsl:call-template>
+                    </xsl:if>
+
+                    <fo:block text-align="left" space-after="1mm">
+                        <fo:inline font-weight="bold" font-size="10pt"><xsl:value-of select="key('kLabels', 'orderAfterCorrection', $labels)"/></fo:inline>
+                    </fo:block>
+                    <xsl:call-template name="zamowienieTable">
+                        <xsl:with-param name="zamowienieWiersz" select="crd:ZamowienieWiersz[not(crd:StanPrzedZ)]"/>
+                    </xsl:call-template>
+                </xsl:when>
+                <!-- Correction with only "before" rows -->
+                <xsl:when test="crd:ZamowienieWiersz[crd:StanPrzedZ = 1]">
+                    <fo:block text-align="left" space-after="1mm">
+                        <fo:inline font-weight="bold" font-size="10pt"><xsl:value-of select="key('kLabels', 'orderBeforeCorrection', $labels)"/></fo:inline>
+                    </fo:block>
+                    <xsl:call-template name="zamowienieTable">
+                        <xsl:with-param name="zamowienieWiersz" select="crd:ZamowienieWiersz[crd:StanPrzedZ = 1]"/>
+                    </xsl:call-template>
+                </xsl:when>
+                <!-- No correction state: a single table -->
+                <xsl:when test="crd:ZamowienieWiersz">
+                    <xsl:call-template name="zamowienieTable">
+                        <xsl:with-param name="zamowienieWiersz" select="crd:ZamowienieWiersz"/>
+                    </xsl:call-template>
+                </xsl:when>
+            </xsl:choose>
+        </fo:block>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/src/test/java/io/alapierre/ksef/fop/AbstractStyleSheetTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/AbstractStyleSheetTest.java
@@ -163,11 +163,31 @@ public abstract class AbstractStyleSheetTest {
      * @param inputUrl    the URL of the input XML document
      * @param inputXpath  an XPath expression used to select the node to transform
      * @param outputXpath an XPath expression used to select the node in the result returned or {@code null}
+     * @param showCorrectionDifferences if {@code true}, shows a diff table of the corrections
+     * @return a new {@link Document} containing the transformation result
+     * @throws Exception on parsing, XPath evaluation or transformation errors
+     */
+    protected static Node transformFa3Invoice(URL inputUrl, String inputXpath, String outputXpath,
+                                              boolean showCorrectionDifferences) throws Exception {
+        return transformXml(inputUrl, FA3_TEMPLATE_URL, inputXpath, outputXpath, transformer -> {
+            setLabelsParam(transformer);
+            transformer.setParameter("showCorrectionDifferences", showCorrectionDifferences);
+        });
+    }
+
+    /**
+     * Transforms an XML document using the FA(3) stylesheet
+     *
+     * <p>This method also provides all the parameters required by the stylesheet.</p>
+     *
+     * @param inputUrl    the URL of the input XML document
+     * @param inputXpath  an XPath expression used to select the node to transform
+     * @param outputXpath an XPath expression used to select the node in the result returned or {@code null}
      * @return a new {@link Document} containing the transformation result
      * @throws Exception on parsing, XPath evaluation or transformation errors
      */
     protected static Node transformFa3Invoice(URL inputUrl, String inputXpath, String outputXpath) throws Exception {
-        return transformXml(inputUrl, FA3_TEMPLATE_URL, inputXpath, outputXpath, AbstractStyleSheetTest::setLabelsParam);
+        return transformFa3Invoice(inputUrl, inputXpath, outputXpath, false);
     }
 }
 

--- a/src/test/java/io/alapierre/ksef/fop/OrderSectionTemplateTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/OrderSectionTemplateTest.java
@@ -1,0 +1,69 @@
+package io.alapierre.ksef.fop;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.w3c.dom.Node;
+import org.xmlunit.assertj3.XmlAssert;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Tests the transformation of the {@code crd:Zamowienie} ("Zamówienie") order section.
+ *
+ * <p>Each fixture below carries a {@code <Zamowienie>} on a different code path:</p>
+ *
+ * <ul>
+ *   <li>{@code basic} — plain VAT invoice (faktura podstawowa) with invoice lines and an order list.</li>
+ *   <li>{@code correction} — correction invoice (korekta, KOR) carrying an order list.</li>
+ *   <li>{@code advance} — ZAL.</li>
+ *   <li>{@code settlement} — ROZ, a non-ZAL invoice.</li>
+ *   <li>{@code correction_stan_przed} — KOR with before/after invoice lines (the order has no StanPrzedZ).</li>
+ *   <li>{@code order_correction} — order rows carry StanPrzedZ, so the section splits into before/after subsections.</li>
+ *   <li>{@code order_before_only} — order rows carry only StanPrzedZ=1, so only the before subsection shows.</li>
+ * </ul>
+ *
+ * @see <a href="https://github.com/ksef4dev/ksef-fop/issues/136">issue #136</a>
+ */
+class OrderSectionTemplateTest extends AbstractStyleSheetTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"basic", "correction", "advance", "settlement", "correction_stan_przed", "order_correction", "order_before_only"})
+    void testTemplate(String resourceName) throws Exception {
+        URL inputUrl = resource("OrderSectionTemplateTest/" + resourceName + ".xml");
+        URL expectedUrl = resource("OrderSectionTemplateTest/" + resourceName + "-expected.xml");
+
+        Node actual = transformFa3Invoice(inputUrl, "/fa3:Faktura", "//fo:block[@id='Zamowienie']");
+
+        XmlAssert.assertThat(actual)
+                .and(expectedUrl)
+                .ignoreWhitespace()
+                .areSimilar();
+    }
+
+    /** With showCorrectionDifferences on, the order section adds a differences table between before and after. */
+    @Test
+    void orderSectionShowsDifferencesWhenEnabled() throws Exception {
+        URL inputUrl = resource("OrderSectionTemplateTest/order_correction.xml");
+        URL expectedUrl = resource("OrderSectionTemplateTest/order_correction-differences-expected.xml");
+
+        Node actual = transformFa3Invoice(inputUrl, "/fa3:Faktura", "//fo:block[@id='Zamowienie']", true);
+
+        XmlAssert.assertThat(actual)
+                .and(expectedUrl)
+                .ignoreWhitespace()
+                .areSimilar();
+    }
+
+    /** No {@code <Zamowienie>} in the source ⇒ no order block in the output. */
+    @Test
+    void orderSectionIsAbsentWhenNoOrder() throws Exception {
+        URL inputUrl = resource("OrderSectionTemplateTest/no_order.xml");
+
+        Node orderBlock = transformFa3Invoice(inputUrl, "/fa3:Faktura", "//fo:block[@id='Zamowienie']");
+
+        assertNull(orderBlock, "Order section must not be emitted when the invoice has no <Zamowienie>");
+    }
+}

--- a/src/test/resources/OrderSectionTemplateTest/advance-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/advance-expected.xml
@@ -1,0 +1,172 @@
+<fo:block xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>123,00 PLN</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Advance-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                            </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/advance.xml
+++ b/src/test/resources/OrderSectionTemplateTest/advance.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Advance invoice (ZAL) carrying an order. This path already rendered the order. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>ZAL/1/02/2026</P_2>
+    <P_15>123.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>ZAL</RodzajFaktury>
+    <Zamowienie>
+      <WartoscZamowienia>123</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Advance-Item</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/basic-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/basic-expected.xml
@@ -1,0 +1,251 @@
+<fo:block xmlns:crd="http://crd.gov.pl/wzor/2025/06/25/13775/"
+          xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          xmlns:local="urn:local"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>246,00 PLN</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Ordered item 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Ordered item 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>50</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/basic.xml
+++ b/src/test/resources/OrderSectionTemplateTest/basic.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Plain VAT invoice (faktura podstawowa) with invoice lines AND a list of ordered items.
+     This is the original issue #136 case: the order was dropped on non-ZAL invoices. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>FV/1/02/2026</P_2>
+    <P_15>246.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>VAT</RodzajFaktury>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>Invoice line 1</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>1</P_8B>
+      <P_9A>100</P_9A>
+      <P_11>100</P_11>
+      <P_12>23</P_12>
+    </FaWiersz>
+    <FaWiersz>
+      <NrWierszaFa>2</NrWierszaFa>
+      <P_7>Invoice line 2</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>2</P_8B>
+      <P_9A>50</P_9A>
+      <P_11>100</P_11>
+      <P_12>23</P_12>
+    </FaWiersz>
+    <Zamowienie>
+      <WartoscZamowienia>246</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Ordered item 1</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+      <ZamowienieWiersz>
+        <NrWierszaZam>2</NrWierszaZam>
+        <P_7Z>Ordered item 2</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>2</P_8BZ>
+        <P_9AZ>50</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/correction-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/correction-expected.xml
@@ -1,0 +1,251 @@
+<fo:block xmlns:crd="http://crd.gov.pl/wzor/2025/06/25/13775/"
+          xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          xmlns:local="urn:local"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>246,00 PLN</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Ordered item 1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Ordered item 2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>50</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/correction.xml
+++ b/src/test/resources/OrderSectionTemplateTest/correction.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Correction invoice (korekta, KOR) with before/after invoice lines and a list of ordered items.
+     The invoice lines go through the StanPrzed correction branch; the order (no StanPrzedZ) must
+     still be rendered as a single table after the positions. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>KOR/1/02/2026</P_2>
+    <P_15>246.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>KOR</RodzajFaktury>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>Invoice line before</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>1</P_8B>
+      <P_11>100</P_11>
+      <P_12>23</P_12>
+      <StanPrzed>1</StanPrzed>
+    </FaWiersz>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>Invoice line after</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>2</P_8B>
+      <P_11>200</P_11>
+      <P_12>23</P_12>
+    </FaWiersz>
+    <Zamowienie>
+      <WartoscZamowienia>246</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Ordered item 1</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+      <ZamowienieWiersz>
+        <NrWierszaZam>2</NrWierszaZam>
+        <P_7Z>Ordered item 2</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>2</P_8BZ>
+        <P_9AZ>50</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/correction_stan_przed-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/correction_stan_przed-expected.xml
@@ -1,0 +1,172 @@
+<fo:block xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>123,00 PLN</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Correction-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                            </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/correction_stan_przed.xml
+++ b/src/test/resources/OrderSectionTemplateTest/correction_stan_przed.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Correction invoice with before/after lines (StanPrzed). Such invoices route into the
+     StanPrzed branch of the positions dispatch, which previously rendered only FaWiersz and
+     dropped any accompanying order. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>KOR/1/02/2026</P_2>
+    <P_15>123.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>KOR</RodzajFaktury>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>Pozycja przed korektą</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>1</P_8B>
+      <P_11>100</P_11>
+      <P_12>23</P_12>
+      <StanPrzed>1</StanPrzed>
+    </FaWiersz>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>Pozycja po korekcie</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>2</P_8B>
+      <P_11>200</P_11>
+      <P_12>23</P_12>
+    </FaWiersz>
+    <Zamowienie>
+      <WartoscZamowienia>123</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Correction-Item</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/no_order.xml
+++ b/src/test/resources/OrderSectionTemplateTest/no_order.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Plain VAT invoice without an order: the order section must not be emitted. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>FV/1/02/2026</P_2>
+    <P_15>123.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>VAT</RodzajFaktury>
+    <FaWiersz>
+      <NrWierszaFa>1</NrWierszaFa>
+      <P_7>Zwykła pozycja</P_7>
+      <P_8A>szt</P_8A>
+      <P_8B>1</P_8B>
+      <P_11>100</P_11>
+      <P_12>23</P_12>
+    </FaWiersz>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/order_before_only-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/order_before_only-expected.xml
@@ -1,0 +1,179 @@
+<fo:block xmlns:crd="http://crd.gov.pl/wzor/2025/06/25/13775/"
+          xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          xmlns:local="urn:local"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>100,00 PLN</fo:inline>
+   </fo:block>
+   <fo:block space-after="1mm" text-align="left">
+      <fo:inline font-size="10pt" font-weight="bold">Pozycje zamówienia przed korektą</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Order-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/order_before_only.xml
+++ b/src/test/resources/OrderSectionTemplateTest/order_before_only.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Order carrying only "before correction" rows (StanPrzedZ=1): only the before subsection shows. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>KOR_ZAL/2/02/2026</P_2>
+    <P_15>100.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>KOR_ZAL</RodzajFaktury>
+    <Zamowienie>
+      <WartoscZamowienia>100</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Order-Item</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+        <StanPrzedZ>1</StanPrzedZ>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/order_correction-differences-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/order_correction-differences-expected.xml
@@ -1,0 +1,499 @@
+<fo:block xmlns:crd="http://crd.gov.pl/wzor/2025/06/25/13775/"
+          xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          xmlns:local="urn:local"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>246,00 PLN</fo:inline>
+   </fo:block>
+   <fo:block space-after="1mm" text-align="left">
+      <fo:inline font-size="10pt" font-weight="bold">Pozycje zamówienia przed korektą</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Order-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+   <fo:block space-after="1mm" text-align="left">
+      <fo:inline font-size="10pt" font-weight="bold">Różnica</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Order-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>0,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+   <fo:block space-after="1mm" text-align="left">
+      <fo:inline font-size="10pt" font-weight="bold">Pozycje zamówienia po korekcie</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Order-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>200,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>46,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/order_correction-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/order_correction-expected.xml
@@ -1,0 +1,340 @@
+<fo:block xmlns:crd="http://crd.gov.pl/wzor/2025/06/25/13775/"
+          xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          xmlns:local="urn:local"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>246,00 PLN</fo:inline>
+   </fo:block>
+   <fo:block space-after="1mm" text-align="left">
+      <fo:inline font-size="10pt" font-weight="bold">Pozycje zamówienia przed korektą</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Order-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+   <fo:block space-after="1mm" text-align="left">
+      <fo:inline font-size="10pt" font-weight="bold">Pozycje zamówienia po korekcie</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Order-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>2</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                    </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>200,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>46,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/order_correction.xml
+++ b/src/test/resources/OrderSectionTemplateTest/order_correction.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Correction of an advance invoice (KOR_ZAL) whose order carries StanPrzedZ before/after rows.
+     The order section must split into "before correction" and "after correction" subsections. -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>KOR_ZAL/1/02/2026</P_2>
+    <P_15>246.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>KOR_ZAL</RodzajFaktury>
+    <Zamowienie>
+      <WartoscZamowienia>246</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Order-Item</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+        <StanPrzedZ>1</StanPrzedZ>
+      </ZamowienieWiersz>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Order-Item</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>2</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>200</P_11NettoZ>
+        <P_11VatZ>46</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>

--- a/src/test/resources/OrderSectionTemplateTest/settlement-expected.xml
+++ b/src/test/resources/OrderSectionTemplateTest/settlement-expected.xml
@@ -1,0 +1,172 @@
+<fo:block xmlns:fo="http://www.w3.org/1999/XSL/Format"
+          id="Zamowienie">
+   <fo:block space-after="2mm" space-before="2mm" text-align="left">
+      <fo:inline font-size="12pt" font-weight="bold">Zamówienie</fo:inline>
+   </fo:block>
+   <fo:block font-size="8pt"
+             font-weight="bold"
+             space-after="3mm"
+             space-before="1mm"
+             text-align="left">
+      <fo:inline>Wartość zamówienia lub umowy z uwzględnieniem kwoty podatku: </fo:inline>
+      <fo:inline>123,00 PLN</fo:inline>
+   </fo:block>
+   <fo:table border-collapse="separate"
+             space-after="5mm"
+             table-layout="fixed"
+             width="100%">
+      <fo:table-column column-width="4%"/>
+      <fo:table-column column-width="36%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="6%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="8%"/>
+      <fo:table-column column-width="12%"/>
+      <fo:table-column column-width="10%"/>
+      <fo:table-header>
+         <fo:table-row background-color="#f5f5f5" font-weight="bold">
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Lp.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Nazwa towaru lub usługi</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Ilość</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Jedn.</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Cena jedn. netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Stawka podatku</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Wartość netto</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt">
+               <fo:block>Kwota VAT</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-header>
+      <fo:table-body>
+         <fo:table-row>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="left">
+               <fo:block>Settlement-Item</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>1</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>szt</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23%
+                                            </fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>100,00</fo:block>
+            </fo:table-cell>
+            <fo:table-cell border="solid 0.2mm black"
+                           font-size="7"
+                           padding-bottom="4pt"
+                           padding-left="4pt"
+                           padding-right="4pt"
+                           padding-top="4pt"
+                           text-align="right">
+               <fo:block>23,00</fo:block>
+            </fo:table-cell>
+         </fo:table-row>
+      </fo:table-body>
+   </fo:table>
+</fo:block>

--- a/src/test/resources/OrderSectionTemplateTest/settlement.xml
+++ b/src/test/resources/OrderSectionTemplateTest/settlement.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Settlement invoice (ROZ): not ZAL/KOR_ZAL, yet it carries an order.
+     Before the fix the <Zamowienie> section was dropped on this path (issue #136). -->
+<Faktura xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+  <Naglowek>
+    <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+    <WariantFormularza>3</WariantFormularza>
+    <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+  </Naglowek>
+  <Podmiot1>
+    <DaneIdentyfikacyjne>
+      <NIP>1111111111</NIP>
+      <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+    </Adres>
+  </Podmiot1>
+  <Podmiot2>
+    <DaneIdentyfikacyjne>
+      <NIP>2222222222</NIP>
+    </DaneIdentyfikacyjne>
+    <Adres>
+      <KodKraju>PL</KodKraju>
+      <AdresL1>ul. Nabywcy 2, 00-002 Warszawa</AdresL1>
+    </Adres>
+    <JST>2</JST>
+    <GV>2</GV>
+  </Podmiot2>
+  <Fa>
+    <KodWaluty>PLN</KodWaluty>
+    <P_1>2026-02-01</P_1>
+    <P_2>ROZ/1/02/2026</P_2>
+    <P_15>123.00</P_15>
+    <Adnotacje>
+      <P_16>2</P_16>
+      <P_17>2</P_17>
+      <P_18>2</P_18>
+      <P_18A>2</P_18A>
+      <Zwolnienie>
+        <P_19N>1</P_19N>
+      </Zwolnienie>
+      <NoweSrodkiTransportu>
+        <P_22N>1</P_22N>
+      </NoweSrodkiTransportu>
+      <P_23>2</P_23>
+      <PMarzy>
+        <P_PMarzyN>1</P_PMarzyN>
+      </PMarzy>
+    </Adnotacje>
+    <RodzajFaktury>ROZ</RodzajFaktury>
+    <FakturaZaliczkowa>
+      <NrKSeFZN>1</NrKSeFZN>
+      <NrFaZaliczkowej>FA/2019/TEST</NrFaZaliczkowej>
+    </FakturaZaliczkowa>
+    <Zamowienie>
+      <WartoscZamowienia>123</WartoscZamowienia>
+      <ZamowienieWiersz>
+        <NrWierszaZam>1</NrWierszaZam>
+        <P_7Z>Settlement-Item</P_7Z>
+        <P_8AZ>szt</P_8AZ>
+        <P_8BZ>1</P_8BZ>
+        <P_9AZ>100</P_9AZ>
+        <P_11NettoZ>100</P_11NettoZ>
+        <P_11VatZ>23</P_11VatZ>
+        <P_12Z>23</P_12Z>
+      </ZamowienieWiersz>
+    </Zamowienie>
+  </Fa>
+</Faktura>


### PR DESCRIPTION
The order section was only emitted for ZAL/KOR_ZAL invoices, so a normal invoice (or any non-advance type) carrying an order list dropped it entirely.

This change:

- extracts the handling of `Zamowienie` into a new `order-invoice.xsl` stylesheet,
- splits the order rows on StanPrzedZ into before/after subsections like `FaWiersz`, with an optional differences table (zamowienieDifferencesTable) gated on showCorrectionDifferences.

Adds `OrderSectionTemplateTest` with fixtures covering basic (VAT), correction (KOR), advance, settlement and the `StanPrzedZ` variants.

Fixes #136

Assisted-By: Claude Opus 4.7 <noreply@anthropic.com>
