### PR TITLE
Resolve http templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.alapierre.ksef</groupId>
     <artifactId>ksef-fop</artifactId>
-    <version>1.2.25-SNAPSHOT</version>
+    <version>1.2.26-SNAPSHOT</version>
 
     <name>KSeF PDF Generator</name>
     <description>Krajowy System eFaktur Generator PDF</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.alapierre.ksef</groupId>
     <artifactId>ksef-fop</artifactId>
-    <version>1.2.26-SNAPSHOT</version>
+    <version>1.2.25-SNAPSHOT</version>
 
     <name>KSeF PDF Generator</name>
     <description>Krajowy System eFaktur Generator PDF</description>

--- a/readme.md
+++ b/readme.md
@@ -156,12 +156,12 @@ XML documents at `i18n/labels.xml` (base / Polish) and `i18n/labels_<lang>.xml` 
 locale. The XSLT stylesheets load these files at runtime via `document()`, routed
 through the **same URIResolver** that resolves custom templates. This means label
 overrides use exactly the same mechanism as template overrides — there is no separate
-"translation root" concept: overrides live under `InvoiceGenerationParams.templateRoots`.
+"translation root" concept: overrides live under `InvoiceGenerationParams.resourceRoots`.
 
 ### 1. Create your labels XML file(s)
 
 Drop them next to any templates you might be overriding, under an `i18n/` directory
-inside one of your `templateRoots`:
+inside one of your `resourceRoots`:
 
 `/etc/ksef/i18n/labels.xml` (Polish / base):
 
@@ -183,14 +183,14 @@ inside one of your `templateRoots`:
 </labels>
 ````
 
-### 2. Point `templateRoots` at the directory containing `i18n/`
+### 2. Point `resourceRoots` at the directory containing `i18n/`
 
 ````java
 InvoiceGenerationParams params = InvoiceGenerationParams.builder()
         .schema(InvoiceSchema.FA3_1_0_E)
         .ksefNumber("1234567890-20231221-XXXXXXXX-XX")
         .language(InvoiceLanguage.EN)
-        .templateRoot(Path.of("/etc/ksef"))
+        .resourceRoot(Paths.get("/etc/ksef").toUri())
         .build();
 
 PdfGenerator generator = new PdfGenerator("fop.xconf");
@@ -237,11 +237,12 @@ supplied one).
 ### Using `TranslationService` directly
 
 You rarely need to touch this class: `PdfGenerator` creates a per-invocation instance
-from your `templateRoots`. If you need to look up labels from Java (e.g. for tooling or
+from your `resourceRoots`. If you need to look up labels from Java (e.g. for tooling or
 tests), pass your own `URIResolver` (most likely a `TemplateResolver`):
 
 ````java
-URIResolver resolver = new TemplateResolver(List.of(Path.of("/etc/ksef")));
+URIResolver resolver = new TemplateResolver(
+        Collections.singletonList(Paths.get("/etc/ksef").toUri()));
 TranslationService ts = new TranslationService(resolver);
 
 String label = ts.getTranslation("en", "seller"); // "Vendor"

--- a/readme.md
+++ b/readme.md
@@ -143,8 +143,10 @@ InvoiceGenerationParams params = InvoiceGenerationParams.builder()
 When `templatePath` is set the library uses it directly; when it is `null` (the default) the
 template is resolved automatically from the schema.
 
-> **Security note:** `templatePath` is used as-is to load a classpath resource. Make sure
-> untrusted users cannot control this value or the underlying XSL content.
+**HTTP(S) URL as `templatePath` (catalog):** you may pass a URL such as `http://localhost:8077/xslt/ksef_invoice` so it lines up with a **template-server** route. `TemplateResolver` does **not** download templates from arbitrary hosts: every allowed `http(s):` stylesheet URI must appear in **`classpath:catalog.xml`**, mapped to a trusted classpath resource (typically your packaged XSLT). Nested `xsl:import` / `xsl:include` that use URLs must be catalogued the same way. See `HttpTemplatePathInvoiceTest` and `src/test/resources/catalog.xml`.
+
+> **Security note:** `templatePath` is resolved through `TemplateResolver` (classpath / template roots /
+> catalog-mapped HTTPS). Make sure untrusted users cannot control this value or inject catalog entries.
 
 ## Custom translations
 

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -1,18 +1,10 @@
 package io.alapierre.ksef.fop;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
+import lombok.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashMap;
@@ -93,23 +85,18 @@ public class InvoiceGenerationParams {
     private String languageLocale;
 
     /**
-     * Optional base URL of a remote template server (e.g. {@code "http://localhost:8077/xslt"}).
-     * <p>
-     * When set, templates/includes resolving under this base are fetched over HTTP (only URLs
-     * within the base; redirects are not followed) instead of from classpath/catalog. Each
-     * stylesheet is fetched once and cached, not on every call. Point this only at a trusted
-     * server (prefer {@code https://} off-loopback); fetched content is not validated.
+     * Ordered list of resource roots searched before the classpath when resolving templates,
+     * translations and relative logo paths.
+     *
+     * <p>Each entry is a {@link URI}: a {@code file:} directory (e.g.
+     * {@code Paths.get("/etc/ksef").toUri()}) or an HTTP(S) base URL
+     * (e.g. {@code URI.create("http://localhost:8077/xslt")}). Templates, {@code i18n/}
+     * label files and logos are resolved relative to these roots.</p>
      */
-    @Nullable
-    private String remoteTemplateBaseUrl;
-
-    /**
-     * Ordered list of filesystem directories searched before the classpath when resolving templates.
-     */
-    @Singular("templateRoot")
+    @Singular("resourceRoot")
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
-    private List<Path> templateRoots;
+    private List<URI> resourceRoots;
 
     /**
      * @deprecated use the builder instead.
@@ -141,15 +128,15 @@ public class InvoiceGenerationParams {
         this.customProperties = customProperties != null ? customProperties : new HashMap<>();
         this.language = language != null ? language : Language.PL;
         this.languageLocale = null;
-        this.templateRoots = Collections.emptyList();
+        this.resourceRoots = Collections.emptyList();
     }
 
     /**
-     * Returns an unmodifiable view of the configured filesystem template roots.
+     * Returns an unmodifiable view of the configured resource roots.
      */
-    public List<Path> getTemplateRoots() {
-        if (templateRoots == null) return Collections.emptyList();
-        return Collections.unmodifiableList(templateRoots);
+    public List<URI> getResourceRoots() {
+        if (resourceRoots == null) return Collections.emptyList();
+        return Collections.unmodifiableList(resourceRoots);
     }
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -93,6 +93,17 @@ public class InvoiceGenerationParams {
     private String languageLocale;
 
     /**
+     * Optional base URL of a remote template server (e.g. {@code "http://localhost:8077/xslt"}).
+     * <p>
+     * When set, templates/includes resolving under this base are fetched over HTTP (only URLs
+     * within the base; redirects are not followed) instead of from classpath/catalog. Each
+     * stylesheet is fetched once and cached, not on every call. Point this only at a trusted
+     * server (prefer {@code https://} off-loopback); fetched content is not validated.
+     */
+    @Nullable
+    private String remoteTemplateBaseUrl;
+
+    /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
     @Singular("templateRoot")

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -22,7 +22,6 @@ import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.net.URI;
-import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -89,8 +88,7 @@ public class PdfGenerator {
         Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
         String upoTemplatePath = resolveUpoTemplatePath(params);
-        TemplateResolver resolver = createTemplateResolver(
-                params.getTemplateRoots(), params.getRemoteTemplateBaseUrl(), upoTemplatePath);
+        TemplateResolver resolver = createTemplateResolver(params.getResourceRoots(), upoTemplatePath);
         TranslationService translationService = new TranslationService(resolver, upoTemplatePath);
         Templates template = XmlFactories.getTemplate(resolver, upoTemplatePath);
         Transformer transformer = template.newTransformer();
@@ -116,8 +114,7 @@ public class PdfGenerator {
                                 OutputStream out) throws TransformerException, FOPException {
         String langCode = params.resolveLanguageTag();
         String templatePath = resolveTemplatePath(params);
-        TemplateResolver resolver = createTemplateResolver(
-                params.getTemplateRoots(), params.getRemoteTemplateBaseUrl(), templatePath);
+        TemplateResolver resolver = createTemplateResolver(params.getResourceRoots(), templatePath);
         TranslationService translationService = new TranslationService(resolver, templatePath);
         QrCodeBuilder qrCodeBuilder = new QrCodeBuilder(translationService);
         List<QrCodeData> qrCodes = qrCodeBuilder.buildQrCodes(params.getInvoiceQRCodeGeneratorRequest(), params.getKsefNumber(), invoiceXml, langCode);
@@ -142,8 +139,7 @@ public class PdfGenerator {
                                          LocalDate duplicateDate,
                                          OutputStream out) throws TransformerException, FOPException {
         String templatePath = resolveTemplatePath(params);
-        TemplateResolver resolver = createTemplateResolver(
-                params.getTemplateRoots(), params.getRemoteTemplateBaseUrl(), templatePath);
+        TemplateResolver resolver = createTemplateResolver(params.getResourceRoots(), templatePath);
         TranslationService translationService = new TranslationService(resolver, templatePath);
         generatePdfInvoice(invoiceXml, params, null, duplicateDate, resolver, translationService, out);
     }
@@ -176,29 +172,29 @@ public class PdfGenerator {
         Templates template = XmlFactories.getTemplate(resolver, stylesheetPath);
         Transformer transformer = template.newTransformer();
 
-        applyParameters(params, qrCodes, duplicateDate, translationService, transformer);
+        applyParameters(params, qrCodes, duplicateDate, resolver, translationService, transformer);
 
         Source xmlSource = new StreamSource(new ByteArrayInputStream(invoiceXml));
         Result result = new SAXResult(fop.getDefaultHandler());
         transformer.transform(xmlSource, result);
     }
 
-    private static TemplateResolver createTemplateResolver(List<Path> roots,
-                                                           @Nullable String remoteTemplateBaseUrl,
+    private static TemplateResolver createTemplateResolver(List<URI> resourceRoots,
                                                            String templatePath) throws TransformerException {
-        TemplateResolver resolver = new TemplateResolver(roots, remoteTemplateBaseUrl);
-        requireHttpTemplatePathUnderRemoteBase(resolver.getRemoteBaseUrl(), templatePath);
+        TemplateResolver resolver = new TemplateResolver(resourceRoots);
+        requireHttpTemplatePathUnderResourceRoots(resolver, templatePath);
         return resolver;
     }
 
     /**
-     * When remote fetching is enabled, an HTTP(S) {@code templatePath} must sit under
-     * {@code remoteTemplateBaseUrl} so misconfiguration fails at setup time.
+     * When HTTP resource roots are configured, an HTTP(S) {@code templatePath} must sit under
+     * one of them so misconfiguration fails at setup time. With no HTTP roots, an HTTP
+     * {@code templatePath} may still resolve via the XML catalog to a classpath resource.
      */
-    private static void requireHttpTemplatePathUnderRemoteBase(@Nullable String remoteBaseUrl,
-                                                               @NotNull String templatePath)
+    private static void requireHttpTemplatePathUnderResourceRoots(@NotNull TemplateResolver resolver,
+                                                                  @NotNull String templatePath)
             throws TransformerException {
-        if (remoteBaseUrl == null || Strings.isEmpty(templatePath)) {
+        if (!resolver.hasHttpResourceRoots() || Strings.isEmpty(templatePath)) {
             return;
         }
         String trimmed = templatePath.trim();
@@ -207,10 +203,10 @@ public class PdfGenerator {
             return;
         }
         String normalized = URI.create(trimmed).normalize().toString();
-        if (!TemplateResolver.isUnderRemoteBase(normalized, remoteBaseUrl)) {
+        if (!resolver.isUnderAnyHttpRoot(normalized)) {
             throw new TransformerException(
-                    "HTTP templatePath is not under remoteTemplateBaseUrl: templatePath="
-                            + templatePath + ", remoteTemplateBaseUrl=" + remoteBaseUrl);
+                    "HTTP templatePath is not under any configured HTTP resource root: templatePath="
+                            + templatePath);
         }
     }
 
@@ -245,8 +241,9 @@ public class PdfGenerator {
     private void applyParameters(InvoiceGenerationParams params,
                                  @Nullable List<QrCodeData> qrCodes,
                                  @Nullable LocalDate duplicateDate,
+                                 @NotNull TemplateResolver resolver,
                                  @NotNull TranslationService translationService,
-                                 @NotNull Transformer transformer) {
+                                 @NotNull Transformer transformer) throws TransformerException {
 
         applyLabelParameters(translationService, params.resolveLanguageTag(), transformer);
 
@@ -257,7 +254,7 @@ public class PdfGenerator {
         }
 
         if (params.getLogoUri() != null) {
-            setParam(transformer, "logoUri", params.getLogoUri().toString());
+            setParam(transformer, "logoUri", resolveLogoUri(resolver, params.getLogoUri()));
         }
 
         if (duplicateDate != null) {
@@ -315,6 +312,27 @@ public class PdfGenerator {
 
     private void setParam(@NotNull Transformer transformer, @NotNull String name, @Nullable Object value) {
         if (value != null) transformer.setParameter(name, value);
+    }
+
+  /**
+     * Resolves a logo URI against configured resource roots when it is a relative path;
+     * absolute {@code file:} / {@code http(s):} URIs are passed through unchanged.
+     */
+    private static String resolveLogoUri(@NotNull TemplateResolver resolver, @NotNull URI logoUri)
+            throws TransformerException {
+        String scheme = logoUri.getScheme();
+        if (scheme != null) {
+            String lower = scheme.toLowerCase(java.util.Locale.ROOT);
+            if ("file".equals(lower) || "http".equals(lower) || "https".equals(lower)) {
+                return logoUri.toString();
+            }
+        }
+        String path = logoUri.getPath();
+        if (path == null || path.isEmpty()) {
+            return logoUri.toString();
+        }
+        return resolver.tryResolvePublicUri(path)
+                .orElse(logoUri.toString());
     }
 
     private FopFactory createFopFactory() {

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -22,6 +22,7 @@ import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -87,9 +88,10 @@ public class PdfGenerator {
         FOUserAgent foUserAgent = fopFactory.newFOUserAgent();
         Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
-        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots(), params.getRemoteTemplateBaseUrl());
-        TranslationService translationService = new TranslationService(resolver);
         String upoTemplatePath = resolveUpoTemplatePath(params);
+        TemplateResolver resolver = createTemplateResolver(
+                params.getTemplateRoots(), params.getRemoteTemplateBaseUrl(), upoTemplatePath);
+        TranslationService translationService = new TranslationService(resolver, upoTemplatePath);
         Templates template = XmlFactories.getTemplate(resolver, upoTemplatePath);
         Transformer transformer = template.newTransformer();
         applyLabelParameters(translationService, params.resolveLanguageTag(), transformer);
@@ -113,8 +115,10 @@ public class PdfGenerator {
                                 InvoiceGenerationParams params,
                                 OutputStream out) throws TransformerException, FOPException {
         String langCode = params.resolveLanguageTag();
-        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots(), params.getRemoteTemplateBaseUrl());
-        TranslationService translationService = new TranslationService(resolver);
+        String templatePath = resolveTemplatePath(params);
+        TemplateResolver resolver = createTemplateResolver(
+                params.getTemplateRoots(), params.getRemoteTemplateBaseUrl(), templatePath);
+        TranslationService translationService = new TranslationService(resolver, templatePath);
         QrCodeBuilder qrCodeBuilder = new QrCodeBuilder(translationService);
         List<QrCodeData> qrCodes = qrCodeBuilder.buildQrCodes(params.getInvoiceQRCodeGeneratorRequest(), params.getKsefNumber(), invoiceXml, langCode);
         generatePdfInvoice(invoiceXml, params, qrCodes, null, resolver, translationService, out);
@@ -137,8 +141,10 @@ public class PdfGenerator {
                                          InvoiceGenerationParams params,
                                          LocalDate duplicateDate,
                                          OutputStream out) throws TransformerException, FOPException {
-        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots(), params.getRemoteTemplateBaseUrl());
-        TranslationService translationService = new TranslationService(resolver);
+        String templatePath = resolveTemplatePath(params);
+        TemplateResolver resolver = createTemplateResolver(
+                params.getTemplateRoots(), params.getRemoteTemplateBaseUrl(), templatePath);
+        TranslationService translationService = new TranslationService(resolver, templatePath);
         generatePdfInvoice(invoiceXml, params, null, duplicateDate, resolver, translationService, out);
     }
 
@@ -175,6 +181,37 @@ public class PdfGenerator {
         Source xmlSource = new StreamSource(new ByteArrayInputStream(invoiceXml));
         Result result = new SAXResult(fop.getDefaultHandler());
         transformer.transform(xmlSource, result);
+    }
+
+    private static TemplateResolver createTemplateResolver(List<Path> roots,
+                                                           @Nullable String remoteTemplateBaseUrl,
+                                                           String templatePath) throws TransformerException {
+        TemplateResolver resolver = new TemplateResolver(roots, remoteTemplateBaseUrl);
+        requireHttpTemplatePathUnderRemoteBase(resolver.getRemoteBaseUrl(), templatePath);
+        return resolver;
+    }
+
+    /**
+     * When remote fetching is enabled, an HTTP(S) {@code templatePath} must sit under
+     * {@code remoteTemplateBaseUrl} so misconfiguration fails at setup time.
+     */
+    private static void requireHttpTemplatePathUnderRemoteBase(@Nullable String remoteBaseUrl,
+                                                               @NotNull String templatePath)
+            throws TransformerException {
+        if (remoteBaseUrl == null || Strings.isEmpty(templatePath)) {
+            return;
+        }
+        String trimmed = templatePath.trim();
+        if (!trimmed.startsWith(TemplateResolver.HTTP_PREFIX)
+                && !trimmed.startsWith(TemplateResolver.HTTPS_PREFIX)) {
+            return;
+        }
+        String normalized = URI.create(trimmed).normalize().toString();
+        if (!TemplateResolver.isUnderRemoteBase(normalized, remoteBaseUrl)) {
+            throw new TransformerException(
+                    "HTTP templatePath is not under remoteTemplateBaseUrl: templatePath="
+                            + templatePath + ", remoteTemplateBaseUrl=" + remoteBaseUrl);
+        }
     }
 
     private @NotNull String resolveTemplatePath(InvoiceGenerationParams params) {

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -87,9 +87,10 @@ public class PdfGenerator {
         FOUserAgent foUserAgent = fopFactory.newFOUserAgent();
         Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
-        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots());
+        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots(), params.getRemoteTemplateBaseUrl());
         TranslationService translationService = new TranslationService(resolver);
-        Templates template = XmlFactories.getTemplate(resolver, resolveUpoTemplatePath(params));
+        String upoTemplatePath = resolveUpoTemplatePath(params);
+        Templates template = XmlFactories.getTemplate(resolver, upoTemplatePath);
         Transformer transformer = template.newTransformer();
         applyLabelParameters(translationService, params.resolveLanguageTag(), transformer);
 
@@ -112,7 +113,7 @@ public class PdfGenerator {
                                 InvoiceGenerationParams params,
                                 OutputStream out) throws TransformerException, FOPException {
         String langCode = params.resolveLanguageTag();
-        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots());
+        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots(), params.getRemoteTemplateBaseUrl());
         TranslationService translationService = new TranslationService(resolver);
         QrCodeBuilder qrCodeBuilder = new QrCodeBuilder(translationService);
         List<QrCodeData> qrCodes = qrCodeBuilder.buildQrCodes(params.getInvoiceQRCodeGeneratorRequest(), params.getKsefNumber(), invoiceXml, langCode);
@@ -136,7 +137,7 @@ public class PdfGenerator {
                                          InvoiceGenerationParams params,
                                          LocalDate duplicateDate,
                                          OutputStream out) throws TransformerException, FOPException {
-        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots());
+        TemplateResolver resolver = new TemplateResolver(params.getTemplateRoots(), params.getRemoteTemplateBaseUrl());
         TranslationService translationService = new TranslationService(resolver);
         generatePdfInvoice(invoiceXml, params, null, duplicateDate, resolver, translationService, out);
     }
@@ -165,7 +166,8 @@ public class PdfGenerator {
         FOUserAgent foUserAgent = fopFactory.newFOUserAgent();
         Fop fop = fopFactory.newFop(MIME_PDF, foUserAgent, out);
 
-        Templates template = XmlFactories.getTemplate(resolver, resolveTemplatePath(params));
+        String stylesheetPath = resolveTemplatePath(params);
+        Templates template = XmlFactories.getTemplate(resolver, stylesheetPath);
         Transformer transformer = template.newTransformer();
 
         applyParameters(params, qrCodes, duplicateDate, translationService, transformer);

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -1,17 +1,10 @@
 package io.alapierre.ksef.fop;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
+import lombok.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Path;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
@@ -53,20 +46,13 @@ public class UpoGenerationParams {
     private String templatePath;
 
     /**
-     * Optional base URL of a remote template server (e.g. {@code "http://localhost:8077/xslt"}).
-     * When set, template hrefs that start with this URL are fetched live over HTTP.
-     * See {@link InvoiceGenerationParams#getRemoteTemplateBaseUrl()} for full documentation.
+     * Ordered list of resource roots (filesystem {@code file:} URIs or HTTP(S) base URLs).
+     * See {@link InvoiceGenerationParams#getResourceRoots()} for full documentation.
      */
-    @Nullable
-    private String remoteTemplateBaseUrl;
-
-    /**
-     * Ordered list of filesystem directories searched before the classpath when resolving templates.
-     */
-    @Singular("templateRoot")
+    @Singular("resourceRoot")
     @Getter(AccessLevel.NONE)
     @Setter(AccessLevel.NONE)
-    private List<Path> templateRoots;
+    private List<URI> resourceRoots;
 
     /**
      * @deprecated use the builder instead.
@@ -77,15 +63,15 @@ public class UpoGenerationParams {
         this.language = language != null ? language : Language.PL;
         this.languageLocale = null;
         this.templatePath = null;
-        this.templateRoots = Collections.emptyList();
+        this.resourceRoots = Collections.emptyList();
     }
 
     /**
-     * Returns an unmodifiable view of the configured filesystem template roots.
+     * Returns an unmodifiable view of the configured resource roots.
      */
-    public List<Path> getTemplateRoots() {
-        if (templateRoots == null) return Collections.emptyList();
-        return Collections.unmodifiableList(templateRoots);
+    public List<URI> getResourceRoots() {
+        if (resourceRoots == null) return Collections.emptyList();
+        return Collections.unmodifiableList(resourceRoots);
     }
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -53,6 +53,14 @@ public class UpoGenerationParams {
     private String templatePath;
 
     /**
+     * Optional base URL of a remote template server (e.g. {@code "http://localhost:8077/xslt"}).
+     * When set, template hrefs that start with this URL are fetched live over HTTP.
+     * See {@link InvoiceGenerationParams#getRemoteTemplateBaseUrl()} for full documentation.
+     */
+    @Nullable
+    private String remoteTemplateBaseUrl;
+
+    /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
     @Singular("templateRoot")

--- a/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
+++ b/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
@@ -188,26 +188,15 @@ public class TranslationService {
 
     @Nullable
     private Document loadRemoteDocument(TemplateResolver templateResolver, String relativePath) {
-        String normalized = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
-        String href = toServeFilename(normalized);
+        String href = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
         try {
             return templateResolver.tryResolve(href, remoteEntryUrl)
-                    .map(source -> parseSource(source, normalized))
+                    .map(source -> parseSource(source, href))
                     .orElse(null);
         } catch (TransformerException e) {
             log.debug("Remote label miss for {} (base {}): {}", href, remoteEntryUrl, e.getMessage());
             return null;
         }
-    }
-
-    /**
-     * Maps classpath paths ({@code i18n/labels_pl.xml}) to flat serve filenames ({@code labels_pl.xml}).
-     */
-    static String toServeFilename(String relativePath) {
-        if (relativePath.startsWith("i18n/")) {
-            return relativePath.substring("i18n/".length());
-        }
-        return relativePath;
     }
 
     private static boolean isRemoteEntryUrl(@Nullable String url) {

--- a/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
+++ b/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
@@ -42,6 +42,13 @@ public class TranslationService {
     private final URIResolver resolver;
     private final DocumentBuilder documentBuilder;
 
+    /**
+     * HTTP(S) entry template URL ({@code templatePath}). When set together with
+     * {@link TemplateResolver#getRemoteBaseUrl()}, label files are fetched relative to it.
+     */
+    @Nullable
+    private final String remoteEntryUrl;
+
     /** No-override service: labels come from the library classpath only. */
     public TranslationService() {
         this(newClasspathOnlyResolver());
@@ -55,7 +62,16 @@ public class TranslationService {
      * and translations.</p>
      */
     public TranslationService(@NotNull URIResolver resolver) {
+        this(resolver, null);
+    }
+
+    /**
+     * @param remoteEntryUrl resolved entry template URL; remote label fetch is enabled only when
+     *                       this is HTTP(S) and the resolver has {@code remoteTemplateBaseUrl} set
+     */
+    public TranslationService(@NotNull URIResolver resolver, @Nullable String remoteEntryUrl) {
         this.resolver = Objects.requireNonNull(resolver, "resolver");
+        this.remoteEntryUrl = resolveRemoteEntryUrl(resolver, remoteEntryUrl);
         try {
             this.documentBuilder = XmlFactories.DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
@@ -71,7 +87,7 @@ public class TranslationService {
      */
     public Document getTranslationsAsXml(String lang) {
         String targetLang = Strings.defaultIfEmpty(lang, DEFAULT_LANGUAGE);
-        return DOCUMENT_CACHE.computeIfAbsent(targetLang, this::loadMergedDocument);
+        return DOCUMENT_CACHE.computeIfAbsent(cacheKey(targetLang), k -> loadMergedDocument(targetLang));
     }
 
     /**
@@ -102,8 +118,10 @@ public class TranslationService {
      * each individual root's partial override is copied on top of the classpath default
      * for the same file name. Priority (earlier wins) is:</p>
      * <ol>
+     *   <li>Locale-specific file from the template server (when {@link #remoteEntryUrl} is set)</li>
      *   <li>Locale-specific file in each user root (in insertion order)</li>
      *   <li>Locale-specific file on the classpath</li>
+     *   <li>Base file from the template server (when {@link #remoteEntryUrl} is set)</li>
      *   <li>Base file in each user root (in insertion order)</li>
      *   <li>Base file on the classpath</li>
      * </ol>
@@ -133,32 +151,94 @@ public class TranslationService {
     }
 
     /**
-     * Loads every parse-able XML document behind {@code relativePath} (user roots first,
-     * then classpath). Missing or unreadable sources are skipped silently — callers treat
-     * the result as "best-effort" and a language with zero hits falls back to an empty doc.
+     * Loads every parse-able XML document behind {@code relativePath}. When {@link #remoteEntryUrl}
+     * is set, tries the template server first (whole file); otherwise, or on miss, uses user roots
+     * and classpath via {@link TemplateResolver#resolveAll(String)}.
      */
     private List<Document> loadAllVariants(String relativePath) {
+        List<Document> docs = new ArrayList<>();
+
+        if (remoteEntryUrl != null && resolver instanceof TemplateResolver) {
+            Document remote = loadRemoteDocument((TemplateResolver) resolver, relativePath);
+            if (remote != null) {
+                docs.add(remote);
+                return docs;
+            }
+        }
+
         List<Source> sources;
         try {
             if (resolver instanceof TemplateResolver) {
                 sources = ((TemplateResolver) resolver).resolveAll(relativePath);
             } else {
-                // Custom resolver: can only give us a single source, so there's no
-                // layering across roots / classpath available from here.
                 Source single = resolveSingle(relativePath);
                 sources = (single == null) ? Collections.emptyList() : Collections.singletonList(single);
             }
         } catch (TransformerException e) {
             log.debug("Resolver error for {}: {}", relativePath, e.getMessage());
-            return Collections.emptyList();
+            return docs;
         }
 
-        List<Document> docs = new ArrayList<>(sources.size());
         for (Source source : sources) {
             Document doc = parseSource(source, relativePath);
             if (doc != null) docs.add(doc);
         }
         return docs;
+    }
+
+    @Nullable
+    private Document loadRemoteDocument(TemplateResolver templateResolver, String relativePath) {
+        String normalized = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+        String href = toServeFilename(normalized);
+        try {
+            return templateResolver.tryResolve(href, remoteEntryUrl)
+                    .map(source -> parseSource(source, normalized))
+                    .orElse(null);
+        } catch (TransformerException e) {
+            log.debug("Remote label miss for {} (base {}): {}", href, remoteEntryUrl, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Maps classpath paths ({@code i18n/labels_pl.xml}) to flat serve filenames ({@code labels_pl.xml}).
+     */
+    static String toServeFilename(String relativePath) {
+        if (relativePath.startsWith("i18n/")) {
+            return relativePath.substring("i18n/".length());
+        }
+        return relativePath;
+    }
+
+    private static boolean isRemoteEntryUrl(@Nullable String url) {
+        if (Strings.isEmpty(url)) {
+            return false;
+        }
+        String trimmed = url.trim();
+        return trimmed.startsWith(TemplateResolver.HTTP_PREFIX)
+                || trimmed.startsWith(TemplateResolver.HTTPS_PREFIX);
+    }
+
+    /**
+     * Remote labels use the same gate as live template fetch: HTTP {@code templatePath} plus
+     * {@code remoteTemplateBaseUrl} on the resolver. Catalog-mapped HTTP paths skip remote labels.
+     */
+    @Nullable
+    private static String resolveRemoteEntryUrl(@NotNull URIResolver resolver, @Nullable String remoteEntryUrl) {
+        if (!isRemoteEntryUrl(remoteEntryUrl)) {
+            return null;
+        }
+        if (resolver instanceof TemplateResolver) {
+            TemplateResolver templateResolver = (TemplateResolver) resolver;
+            if (templateResolver.getRemoteBaseUrl() != null) {
+                return remoteEntryUrl.trim();
+            }
+        }
+        return null;
+    }
+
+    private String cacheKey(String lang) {
+        return (remoteEntryUrl != null ? remoteEntryUrl : "") + "|" + lang;
     }
 
     @Nullable

--- a/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
+++ b/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
@@ -44,7 +44,7 @@ public class TranslationService {
 
     /**
      * HTTP(S) entry template URL ({@code templatePath}). When set together with
-     * {@link TemplateResolver#getRemoteBaseUrl()}, label files are fetched relative to it.
+     * a configured HTTP resource root, label files are fetched relative to it.
      */
     @Nullable
     private final String remoteEntryUrl;
@@ -67,7 +67,7 @@ public class TranslationService {
 
     /**
      * @param remoteEntryUrl resolved entry template URL; remote label fetch is enabled only when
-     *                       this is HTTP(S) and the resolver has {@code remoteTemplateBaseUrl} set
+     *                       this is HTTP(S) and under a configured HTTP resource root
      */
     public TranslationService(@NotNull URIResolver resolver, @Nullable String remoteEntryUrl) {
         this.resolver = Objects.requireNonNull(resolver, "resolver");
@@ -209,8 +209,8 @@ public class TranslationService {
     }
 
     /**
-     * Remote labels use the same gate as live template fetch: HTTP {@code templatePath} plus
-     * {@code remoteTemplateBaseUrl} on the resolver. Catalog-mapped HTTP paths skip remote labels.
+     * Remote labels use the same gate as live template fetch: HTTP {@code templatePath} under
+     * a configured HTTP resource root. Catalog-mapped HTTP paths skip remote labels.
      */
     @Nullable
     private static String resolveRemoteEntryUrl(@NotNull URIResolver resolver, @Nullable String remoteEntryUrl) {
@@ -219,8 +219,9 @@ public class TranslationService {
         }
         if (resolver instanceof TemplateResolver) {
             TemplateResolver templateResolver = (TemplateResolver) resolver;
-            if (templateResolver.getRemoteBaseUrl() != null) {
-                return remoteEntryUrl.trim();
+            String trimmed = remoteEntryUrl.trim();
+            if (templateResolver.isUnderAnyHttpRoot(trimmed)) {
+                return trimmed;
             }
         }
         return null;

--- a/src/main/java/io/alapierre/ksef/fop/internal/PathResourceRoot.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/PathResourceRoot.java
@@ -1,0 +1,71 @@
+package io.alapierre.ksef.fop.internal;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Filesystem ({@code file:}) resource root.
+ */
+final class PathResourceRoot extends ResourceRoot {
+
+    private static final String VFS_PREFIX = "vfs:///";
+
+    private final Path root;
+
+    PathResourceRoot(@NotNull Path canonicalRoot) {
+        this.root = Objects.requireNonNull(canonicalRoot, "canonicalRoot");
+    }
+
+    @NotNull
+    Path getRoot() {
+        return root;
+    }
+
+    @Override
+    @Nullable
+    Source tryResolveRelative(@NotNull String relativePath) throws TransformerException {
+        Optional<Path> resolved = FilesystemRoots.resolveFileWithin(root, relativePath);
+        if (!resolved.isPresent()) {
+            return null;
+        }
+        try {
+            return new StreamSource(Files.newInputStream(resolved.get()), VFS_PREFIX + relativePath);
+        } catch (IOException e) {
+            throw new TransformerException("File is not accessible: " + resolved.get(), e);
+        }
+    }
+
+    @Override
+    @NotNull
+    Optional<String> tryResolvePublicUri(@NotNull String relativePath) throws TransformerException {
+        Optional<Path> resolved = FilesystemRoots.resolveFileWithin(root, relativePath);
+        return resolved.map(path -> path.toUri().toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PathResourceRoot)) return false;
+        PathResourceRoot that = (PathResourceRoot) o;
+        return Objects.equals(root, that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(root);
+    }
+
+    @Override
+    public String toString() {
+        return "PathResourceRoot{" + root + "}";
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoot.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoot.java
@@ -1,0 +1,78 @@
+package io.alapierre.ksef.fop.internal;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * A single canonicalised resource root — either a filesystem directory or an HTTP(S) base URL.
+ */
+final class ResourceRoot {
+
+    private final Path filesystemPath;
+    private final String httpBaseUrl;
+
+    private ResourceRoot(@Nullable Path filesystemPath, @Nullable String httpBaseUrl) {
+        this.filesystemPath = filesystemPath;
+        this.httpBaseUrl = httpBaseUrl;
+    }
+
+    static @NotNull ResourceRoot filesystem(@NotNull Path canonicalPath) {
+        return new ResourceRoot(canonicalPath, null);
+    }
+
+    static @NotNull ResourceRoot http(@NotNull String canonicalBaseUrl) {
+        return new ResourceRoot(null, canonicalBaseUrl);
+    }
+
+    boolean isHttp() {
+        return httpBaseUrl != null;
+    }
+
+    @NotNull
+    Path getFilesystemPath() {
+        if (filesystemPath == null) {
+            throw new IllegalStateException("Not a filesystem root: " + httpBaseUrl);
+        }
+        return filesystemPath;
+    }
+
+    @NotNull
+    String getHttpBaseUrl() {
+        if (httpBaseUrl == null) {
+            throw new IllegalStateException("Not an HTTP root: " + filesystemPath);
+        }
+        return httpBaseUrl;
+    }
+
+    boolean isUnder(@NotNull String url) {
+        return isHttp() && TemplateResolver.isUnderRemoteBase(url, httpBaseUrl);
+    }
+
+    @NotNull
+    String resolveUrl(@NotNull String relativePath) {
+        String path = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+        return getHttpBaseUrl() + "/" + path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ResourceRoot)) return false;
+        ResourceRoot that = (ResourceRoot) o;
+        return Objects.equals(filesystemPath, that.filesystemPath)
+                && Objects.equals(httpBaseUrl, that.httpBaseUrl);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(filesystemPath, httpBaseUrl);
+    }
+
+    @Override
+    public String toString() {
+        return isHttp() ? "ResourceRoot{http=" + httpBaseUrl + "}" : "ResourceRoot{file=" + filesystemPath + "}";
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoot.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoot.java
@@ -3,76 +3,54 @@ package io.alapierre.ksef.fop.internal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.file.Path;
-import java.util.Objects;
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import java.util.Optional;
 
 /**
- * A single canonicalised resource root — either a filesystem directory or an HTTP(S) base URL.
+ * A single canonicalised resource root used by {@link TemplateResolver}.
  */
-final class ResourceRoot {
+abstract class ResourceRoot {
 
-    private final Path filesystemPath;
-    private final String httpBaseUrl;
+    /**
+     * Tries to load {@code relativePath} from this root. Returns {@code null} on a miss.
+     */
+    @Nullable
+    abstract Source tryResolveRelative(@NotNull String relativePath) throws TransformerException;
 
-    private ResourceRoot(@Nullable Path filesystemPath, @Nullable String httpBaseUrl) {
-        this.filesystemPath = filesystemPath;
-        this.httpBaseUrl = httpBaseUrl;
-    }
-
-    static @NotNull ResourceRoot filesystem(@NotNull Path canonicalPath) {
-        return new ResourceRoot(canonicalPath, null);
-    }
-
-    static @NotNull ResourceRoot http(@NotNull String canonicalBaseUrl) {
-        return new ResourceRoot(null, canonicalBaseUrl);
-    }
+    /**
+     * Resolves a relative path to a public URI ({@code file:} or {@code http(s):}) when the
+     * resource exists under this root.
+     */
+    abstract @NotNull Optional<String> tryResolvePublicUri(@NotNull String relativePath)
+            throws TransformerException;
 
     boolean isHttp() {
-        return httpBaseUrl != null;
+        return false;
     }
 
-    @NotNull
-    Path getFilesystemPath() {
-        if (filesystemPath == null) {
-            throw new IllegalStateException("Not a filesystem root: " + httpBaseUrl);
-        }
-        return filesystemPath;
+    /**
+     * Whether {@code url} lies under this root. Always {@code false} for non-HTTP roots.
+     */
+    boolean contains(@NotNull String url) {
+        return false;
     }
 
-    @NotNull
-    String getHttpBaseUrl() {
-        if (httpBaseUrl == null) {
-            throw new IllegalStateException("Not an HTTP root: " + filesystemPath);
-        }
-        return httpBaseUrl;
+    /**
+     * Fetches an absolute URL when it lies under this HTTP root. Returns {@code null} when this
+     * is not an HTTP root or the URL is outside the root.
+     */
+    @Nullable
+    Source tryFetchAbsolute(@NotNull String url) throws TransformerException {
+        return null;
     }
 
-    boolean isUnder(@NotNull String url) {
-        return isHttp() && TemplateResolver.isUnderRemoteBase(url, httpBaseUrl);
-    }
-
-    @NotNull
-    String resolveUrl(@NotNull String relativePath) {
-        String path = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
-        return getHttpBaseUrl() + "/" + path;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ResourceRoot)) return false;
-        ResourceRoot that = (ResourceRoot) o;
-        return Objects.equals(filesystemPath, that.filesystemPath)
-                && Objects.equals(httpBaseUrl, that.httpBaseUrl);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(filesystemPath, httpBaseUrl);
-    }
-
-    @Override
-    public String toString() {
-        return isHttp() ? "ResourceRoot{http=" + httpBaseUrl + "}" : "ResourceRoot{file=" + filesystemPath + "}";
+    /**
+     * Resolves {@code href} against an HTTP {@code base} that lies under this root and fetches
+     * the result. Returns {@code null} when not applicable or on a miss.
+     */
+    @Nullable
+    Source tryFetchRelativeToBase(@NotNull String href, @NotNull String base) throws TransformerException {
+        return null;
     }
 }

--- a/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoots.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoots.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 
 /**
  * Canonicalises {@link URI} resource roots (filesystem directories and HTTP(S) base URLs).
@@ -20,7 +19,6 @@ public final class ResourceRoots {
 
     private ResourceRoots() {
     }
-
 
     public static boolean isHttp(@NotNull URI root) {
         String scheme = root.getScheme();
@@ -44,11 +42,11 @@ public final class ResourceRoots {
                 throw new IllegalArgumentException("Resource root must not be null");
             }
             if (isHttp(root)) {
-                result.add(ResourceRoot.http(TemplateResolver.canonicalizeHttpBaseUrl(root.toString())));
+                result.add(UrlResourceRoot.canonicalize(root));
             } else if (isFilesystem(root)) {
                 Path canonical = FilesystemRoots.canonicalize(
                         Collections.singletonList(toFilesystemPath(root))).get(0);
-                result.add(ResourceRoot.filesystem(canonical));
+                result.add(new PathResourceRoot(canonical));
             } else {
                 throw new TransformerException(
                         "Resource root must be a file: directory or http(s) URL: " + root);

--- a/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoots.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoots.java
@@ -1,0 +1,66 @@
+package io.alapierre.ksef.fop.internal;
+
+import org.jetbrains.annotations.NotNull;
+
+import javax.xml.transform.TransformerException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Canonicalises {@link URI} resource roots (filesystem directories and HTTP(S) base URLs).
+ */
+public final class ResourceRoots {
+
+    private ResourceRoots() {
+    }
+
+
+    public static boolean isHttp(@NotNull URI root) {
+        String scheme = root.getScheme();
+        if (scheme == null) {
+            return false;
+        }
+        String lower = scheme.toLowerCase(Locale.ROOT);
+        return "http".equals(lower) || "https".equals(lower);
+    }
+
+    public static boolean isFilesystem(@NotNull URI root) {
+        String scheme = root.getScheme();
+        return scheme == null || "file".equalsIgnoreCase(scheme);
+    }
+
+    public static @NotNull List<ResourceRoot> canonicalize(@NotNull List<URI> roots)
+            throws IOException, TransformerException {
+        List<ResourceRoot> result = new ArrayList<>(roots.size());
+        for (URI root : roots) {
+            if (root == null) {
+                throw new IllegalArgumentException("Resource root must not be null");
+            }
+            if (isHttp(root)) {
+                result.add(ResourceRoot.http(TemplateResolver.canonicalizeHttpBaseUrl(root.toString())));
+            } else if (isFilesystem(root)) {
+                Path canonical = FilesystemRoots.canonicalize(
+                        Collections.singletonList(toFilesystemPath(root))).get(0);
+                result.add(ResourceRoot.filesystem(canonical));
+            } else {
+                throw new TransformerException(
+                        "Resource root must be a file: directory or http(s) URL: " + root);
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private static @NotNull Path toFilesystemPath(@NotNull URI root) {
+        if ("file".equalsIgnoreCase(root.getScheme())) {
+            return Paths.get(root);
+        }
+        return Paths.get(root.getPath());
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -34,25 +34,30 @@ import java.util.Optional;
 /**
  * URI resolver for XSLT template loading.
  *
- * <p>Resolution order for each {@code href}:</p>
+ * <p>Every resource is looked up in the following order:</p>
  * <ol>
- *   <li>When {@code remoteBaseUrl} is set: absolute or relatively-resolved URLs under that base
- *       are fetched over HTTP from the template server.</li>
- *   <li>Remaining {@code http:} / {@code https:} URIs are rewritten via the XML catalog to a
- *       {@code classpath:} resource (no network I/O to the original URL).</li>
- *   <li>Filesystem template roots, then classpath, for non-URL paths.</li>
+ *   <li>When HTTP(S) resource roots are configured: absolute {@code href} values under such a
+ *       root, and relative {@code href} values whose {@code base} sits under such a root, are
+ *       fetched over HTTP (GET; redirects are not followed).</li>
+ *   <li>If the resource name starts with {@code http:} or {@code https:} and was not loaded
+ *       in step&nbsp;1, it is resolved using the XML catalog (allowlisted entries rewrite to
+ *       {@code classpath:} resources — no network I/O to the original URL).</li>
+ *   <li>Each configured resource root ({@code file:} directory or {@code http(s):} base), in
+ *       insertion order.</li>
+ *   <li>Classpath.</li>
  * </ol>
+ * <p>Anything unresolved throws {@link TransformerException}.</p>
  *
  * <p><strong>Containment guarantee.</strong> For each filesystem root, the resolved path is
  * verified to remain within the root. Both {@code ..} traversal and symlinks pointing outside
- * the root are rejected.</p>
+ * the root are rejected. For HTTP roots, a URL resolving outside the configured base
+ * ({@code ../} escapes, authority changes) is rejected.</p>
  *
  * <p>System IDs produced by this resolver use the {@code vfs:} scheme
  * (e.g. {@code vfs:///templates/fa3/ksef_invoice.xsl}) so that Saxon treats them as
- * absolute and does not attempt to resolve them against the JVM working directory.</p>
- *
- * <p>Remote fetching is contained: a URL resolving outside {@code remoteBaseUrl} ({@code ../}
- * escapes, authority changes) is rejected and HTTP redirects are not followed.</p>
+ * absolute and does not attempt to resolve them against the JVM working directory.
+ * Resources fetched over HTTP use the source URL as the system ID so Saxon resolves relative
+ * {@code xsl:import}/{@code include} hrefs against it.</p>
  *
  * <p>This class is <strong>internal</strong> and may change between releases.</p>
  */
@@ -72,74 +77,55 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     private static final String VFS_PREFIX = VFS_SCHEME + ":///";
     private static final URI VFS_ROOT = URI.create(VFS_PREFIX);
 
-    private final List<Path> roots;
+    private final List<ResourceRoot> resourceRoots;
     private final CatalogManager catalogManager;
 
-    /**
-     * When non-null, hrefs that start with this prefix are fetched over HTTP instead of
-     * being looked up in the XML catalog.  All other {@code http(s):} hrefs still use the
-     * catalog (e.g. external XSD files like KodyKrajow).
-     */
-    @Nullable
-    private final String remoteBaseUrl;
-
-    /** Constructs a resolver without remote HTTP support (catalog / classpath only). */
-    public TemplateResolver(List<Path> roots) throws TransformerException {
-        this(roots, null);
+    /** Constructs a resolver without user resource roots (classpath / catalog only). */
+    public TemplateResolver() throws TransformerException {
+        this(Collections.emptyList());
     }
 
     /**
-     * Constructs a resolver with optional remote HTTP support.
+     * Constructs a resolver from ordered resource roots.
      *
-     * @param roots         ordered filesystem roots searched before the classpath
-     * @param remoteBaseUrl base URL of the remote template server
-     *                      (e.g. {@code "http://localhost:8077/xslt"}).
-     *                      Pass {@code null} to disable remote fetching.
+     * @param roots ordered list of filesystem ({@code file:}) or HTTP(S) base URIs
      */
-    public TemplateResolver(List<Path> roots, @Nullable String remoteBaseUrl) throws TransformerException {
+    public TemplateResolver(List<URI> roots) throws TransformerException {
         try {
-            this.roots = FilesystemRoots.canonicalize(roots);
+            this.resourceRoots = ResourceRoots.canonicalize(roots);
         } catch (IOException e) {
-            throw new TransformerException("Template root is not accessible: " + e.getMessage(), e);
+            throw new TransformerException("Resource root is not accessible: " + e.getMessage(), e);
         }
         XMLResolverConfiguration config = new XMLResolverConfiguration();
         config.setFeature(ResolverFeature.CATALOG_FILES,
                 Collections.singletonList("classpath:catalog.xml"));
         this.catalogManager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
-        this.remoteBaseUrl = canonicalizeRemoteBaseUrl(remoteBaseUrl);
     }
 
     /**
-     * Validates and normalizes a remote template-server base URL.
-     *
-     * <p>{@code null} or blank (after trim) disables remote fetching. Otherwise the value must
-     * be a syntactically valid {@code http:} / {@code https:} URI with a host; trailing slashes
-     * are stripped.</p>
+     * Validates and normalizes an HTTP(S) resource-root base URL.
      */
-    @Nullable
-    static String canonicalizeRemoteBaseUrl(@Nullable String remoteBaseUrl) throws TransformerException {
-        if (remoteBaseUrl == null) {
-            return null;
-        }
-        String trimmed = remoteBaseUrl.trim();
+    @NotNull
+    static String canonicalizeHttpBaseUrl(@NotNull String baseUrl) throws TransformerException {
+        String trimmed = baseUrl.trim();
         if (trimmed.isEmpty()) {
-            return null;
+            throw new TransformerException("HTTP resource root must not be blank");
         }
         URI uri = parseUri(trimmed);
         String scheme = uri.getScheme();
         if (scheme == null) {
             throw new TransformerException(
-                    "Remote template base URL must use http or https scheme: " + remoteBaseUrl);
+                    "HTTP resource root must use http or https scheme: " + baseUrl);
         }
         String schemeLower = scheme.toLowerCase(Locale.ROOT);
         if (!"http".equals(schemeLower) && !"https".equals(schemeLower)) {
             throw new TransformerException(
-                    "Remote template base URL must use http or https scheme: " + remoteBaseUrl);
+                    "HTTP resource root must use http or https scheme: " + baseUrl);
         }
         String host = uri.getHost();
         if (host == null || host.isEmpty()) {
             throw new TransformerException(
-                    "Remote template base URL must have a host: " + remoteBaseUrl);
+                    "HTTP resource root must have a host: " + baseUrl);
         }
         return stripTrailingSlashes(uri.normalize().toString());
     }
@@ -153,19 +139,33 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     }
 
     /**
-     * True if {@code url} equals {@code remoteBaseUrl} or sits under it as a path segment.
+     * True if {@code url} equals {@code httpRoot} or sits under it as a path segment.
      */
-    public static boolean isUnderRemoteBase(@NotNull String url, @NotNull String remoteBaseUrl) {
-        return url.equals(remoteBaseUrl) || url.startsWith(remoteBaseUrl + "/");
+    public static boolean isUnderRemoteBase(@NotNull String url, @NotNull String httpRoot) {
+        return url.equals(httpRoot) || url.startsWith(httpRoot + "/");
     }
 
-    List<Path> getRoots() {
-        return roots;
+    @NotNull
+    List<ResourceRoot> getResourceRoots() {
+        return resourceRoots;
     }
 
-    @Nullable
-    public String getRemoteBaseUrl() {
-        return remoteBaseUrl;
+    public boolean hasHttpResourceRoots() {
+        for (ResourceRoot root : resourceRoots) {
+            if (root.isHttp()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isUnderAnyHttpRoot(@NotNull String url) {
+        for (ResourceRoot root : resourceRoots) {
+            if (root.isUnder(url)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -188,7 +188,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
      *
      * <p>Genuine programmer errors (null {@code href}, malformed URIs, unsupported URI
      * schemes, or http/https URIs missing from the XML catalog) still propagate as
-     * {@link TransformerException}. "Not found" for filesystem+classpath is the only
+     * {@link TransformerException}. "Not found" for resource roots and classpath is the only
      * condition that collapses to an empty result.</p>
      */
     public Optional<Source> tryResolve(String href, String base) throws TransformerException {
@@ -196,20 +196,16 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             throw new TransformerException("Cannot resolve null href");
         }
 
-        // 0. Remote HTTP/HTTPS fetch from the configured template server.
-        //    This takes priority over the catalog so that stylesheets are loaded from
-        //    the server rather than from the bundled classpath copies.
-        if (remoteBaseUrl != null) {
-            // a) Absolute href that belongs to the remote server.
-            if (isUnderRemoteBase(href)) {
-                return Optional.of(fetchFromRemote(requireUnderRemoteBase(normalizeUrl(href), href, base)));
-            }
-            // b) Relative href whose parent stylesheet was fetched from the remote server.
-            //    base will be the HTTP URL of the parent (set as systemId when it was loaded).
-            if (base != null && isUnderRemoteBase(base) && !href.contains(":")) {
-                String resolved = URI.create(base).resolve(href).normalize().toString();
-                return Optional.of(fetchFromRemote(requireUnderRemoteBase(resolved, href, base)));
-            }
+        // 0. Remote HTTP/HTTPS fetch from configured resource roots.
+        //    a) Absolute href under an HTTP root.
+        //    b) Relative href whose parent stylesheet was fetched from an HTTP root
+        //       (base is the HTTP URL of the parent, set as systemId when it was loaded).
+        if (isUnderAnyHttpRoot(href)) {
+            return Optional.of(fetchFromRemote(requireUnderHttpRoot(normalizeUrl(href), href, base)));
+        }
+        if (base != null && isUnderAnyHttpRoot(base) && !href.contains(":")) {
+            String resolved = URI.create(base).resolve(href).normalize().toString();
+            return Optional.of(fetchFromRemote(requireUnderHttpRoot(resolved, href, base)));
         }
 
         // 1. http: / https: URIs → XML catalog (allowlist); anything not listed throws
@@ -236,7 +232,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             throw new TransformerException("Unsupported URI scheme in href: " + href);
         }
 
-        // 2 + 3. Derive the effective relative path, then try filesystem roots and classpath.
+        // 2 + 3. Derive the effective relative path, then try resource roots and classpath.
         // Root-relative hrefs bypass the base URI: this keeps them portable across whatever
         // base URI the XSLT engine feeds us (file:, vfs:, jar:, …) and avoids the need to
         // validate the base scheme when the caller has already said "this path is absolute".
@@ -249,9 +245,11 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             relativePath = virtualUri.getPath().substring(1);
         }
 
-        for (Path root : roots) {
-            Source s = tryFilesystem(root, relativePath);
-            if (s != null) return Optional.of(s);
+        for (ResourceRoot root : resourceRoots) {
+            Source s = tryResolveAtRoot(root, relativePath);
+            if (s != null) {
+                return Optional.of(s);
+            }
         }
 
         Source s = tryClasspath(relativePath);
@@ -259,7 +257,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     }
 
     /**
-     * Collects every resolvable source for {@code href} — one per configured filesystem root
+     * Collects every resolvable source for {@code href} — one per configured resource root
      * that contains a match, followed by the classpath entry if present. Unlike
      * {@link #tryResolve(String, String)}, which stops at the first hit, this is used by
      * layered resources such as i18n labels that must be overlaid on top of the classpath
@@ -286,32 +284,58 @@ public class TemplateResolver implements NonDelegatingURIResolver {
 
         String relativePath = href.startsWith("/") ? href.substring(1) : href;
 
-        List<Source> sources = new ArrayList<>(roots.size() + 1);
-        for (Path root : roots) {
-            Source s = tryFilesystem(root, relativePath);
-            if (s != null) sources.add(s);
+        List<Source> sources = new ArrayList<>(resourceRoots.size() + 1);
+        for (ResourceRoot root : resourceRoots) {
+            Source s = tryResolveAtRoot(root, relativePath);
+            if (s != null) {
+                sources.add(s);
+            }
         }
         Source cp = tryClasspath(relativePath);
         if (cp != null) sources.add(cp);
         return sources;
     }
 
+    /**
+     * Resolves a relative resource to a public URI suitable for FOP external references
+     * ({@code file:} or {@code http(s):}).
+     */
+    public Optional<String> tryResolvePublicUri(String href) {
+        if (href == null || href.contains(":")) {
+            return Optional.empty();
+        }
+        String relativePath = href.startsWith("/") ? href.substring(1) : href;
+
+        for (ResourceRoot root : resourceRoots) {
+            if (root.isHttp()) {
+                String url = root.resolveUrl(relativePath);
+                if (tryFetchFromRemote(url) != null) {
+                    return Optional.of(url);
+                }
+            } else {
+                Optional<Path> resolved = FilesystemRoots.resolveFileWithin(
+                        root.getFilesystemPath(), relativePath);
+                if (resolved.isPresent()) {
+                    return Optional.of(resolved.get().toUri().toString());
+                }
+            }
+        }
+
+        URL classpathUrl = TemplateResolver.class.getClassLoader().getResource(relativePath);
+        if (classpathUrl != null) {
+            return Optional.of(classpathUrl.toString());
+        }
+        return Optional.empty();
+    }
+
     // -----------------------------------------------------------------------
     // Remote HTTP fetch
     // -----------------------------------------------------------------------
 
-    private boolean isUnderRemoteBase(String url) {
-        return isUnderRemoteBase(url, remoteBaseUrl);
-    }
-
-    /**
-     * Rejects a resolved URL that escapes the base (e.g. {@code ../} path escape or a
-     * protocol-relative authority change), which raw href/base checks can miss.
-     */
-    private String requireUnderRemoteBase(String resolvedUrl, String href, String base) throws TransformerException {
-        if (!isUnderRemoteBase(resolvedUrl)) {
-            throw new TransformerException("Remote template href escapes the configured base '"
-                    + remoteBaseUrl + "': " + href
+    private String requireUnderHttpRoot(String resolvedUrl, String href, String base) throws TransformerException {
+        if (!isUnderAnyHttpRoot(resolvedUrl)) {
+            throw new TransformerException("Remote template href escapes configured HTTP resource root(s): "
+                    + href
                     + (Strings.isEmpty(base) ? "" : " (base: " + base + ")")
                     + " resolved to " + resolvedUrl);
         }
@@ -322,19 +346,34 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         return URI.create(url).normalize().toString();
     }
 
+    @Nullable
+    private Source tryResolveAtRoot(ResourceRoot root, String relativePath) throws TransformerException {
+        if (root.isHttp()) {
+            return tryFetchFromRemote(root.resolveUrl(relativePath));
+        }
+        return tryFilesystem(root.getFilesystemPath(), relativePath);
+    }
+
     /**
-     * Fetches a stylesheet over HTTP. The URL is used as the source systemId so Saxon resolves
-     * relative {@code xsl:import}/{@code include} hrefs against it (re-entering as case 0b).
+     * Single GET; returns {@code null} on 404 / network error (used when probing HTTP roots).
      */
+    @Nullable
+    private Source tryFetchFromRemote(String url) {
+        try {
+            return fetchFromRemote(url);
+        } catch (TransformerException e) {
+            log.debug("Remote resource miss for {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
     private Source fetchFromRemote(String url) throws TransformerException {
-        log.debug("XSLT: fetching stylesheet from remote template server: {}", url);
+        log.debug("XSLT: fetching resource from remote server: {}", url);
         HttpURLConnection connection = null;
         try {
             connection = (HttpURLConnection) new URL(url).openConnection();
             connection.setConnectTimeout(REMOTE_TIMEOUT_MS);
             connection.setReadTimeout(REMOTE_TIMEOUT_MS);
-            // Do not follow redirects: a 3xx could send the fetch to an arbitrary host outside
-            // the configured base, defeating the containment check. Treat any non-200 as an error.
             connection.setInstanceFollowRedirects(false);
             connection.setRequestProperty("Accept", "application/xslt+xml, text/xml, application/xml, */*");
             connection.setRequestMethod("GET");
@@ -342,18 +381,16 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             int status = connection.getResponseCode();
             if (status != HttpURLConnection.HTTP_OK) {
                 throw new TransformerException(
-                        "Remote template server returned HTTP " + status + " for URL: " + url);
+                        "Remote resource server returned HTTP " + status + " for URL: " + url);
             }
 
-            // Copy the response body into memory so the connection can be closed cleanly
-            // while Saxon still has an InputStream to read from.
             byte[] body = readFully(connection.getInputStream());
             log.debug("XSLT: fetched {} bytes from {}", body.length, url);
             return new StreamSource(new ByteArrayInputStream(body), url);
 
         } catch (IOException e) {
             throw new TransformerException(
-                    "Failed to fetch remote template (server may be down): " + url + " — " + e.getMessage(), e);
+                    "Failed to fetch remote resource (server may be down): " + url + " — " + e.getMessage(), e);
         } finally {
             if (connection != null) connection.disconnect();
         }
@@ -366,7 +403,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         while ((n = in.read(chunk)) != -1) {
             buf.write(chunk, 0, n);
             if (buf.size() > MAX_REMOTE_TEMPLATE_BYTES) {
-                throw new TransformerException("Remote template exceeds maximum allowed size of "
+                throw new TransformerException("Remote resource exceeds maximum allowed size of "
                         + MAX_REMOTE_TEMPLATE_BYTES + " bytes");
             }
         }

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -141,7 +141,15 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             throw new TransformerException(
                     "Remote template base URL must have a host: " + remoteBaseUrl);
         }
-        return uri.normalize().toString().replaceAll("/+$", "");
+        return stripTrailingSlashes(uri.normalize().toString());
+    }
+
+    private static String stripTrailingSlashes(String value) {
+        int end = value.length();
+        while (end > 0 && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return end == value.length() ? value : value.substring(0, end);
     }
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -4,6 +4,9 @@
 package io.alapierre.ksef.fop.internal;
 
 import net.sf.saxon.trans.NonDelegatingURIResolver;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xmlresolver.CatalogManager;
 import org.xmlresolver.ResolverFeature;
 import org.xmlresolver.XMLResolverConfiguration;
@@ -11,10 +14,14 @@ import org.xmlresolver.XMLResolverConfiguration;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -25,14 +32,14 @@ import java.util.Optional;
 /**
  * URI resolver for XSLT template loading.
  *
- * <p>Every resource is looked up in the following order:</p>
+ * <p>Resolution order for each {@code href}:</p>
  * <ol>
- *   <li>If the resource name starts with {@code http:} or {@code https:}, it is resolved
- *       using an XML catalog.</li>
- *   <li>Each configured filesystem root, in insertion order.</li>
- *   <li>Classpath.</li>
+ *   <li>When {@code remoteBaseUrl} is set: absolute or relatively-resolved URLs under that base
+ *       are fetched over HTTP from the template server.</li>
+ *   <li>Remaining {@code http:} / {@code https:} URIs are rewritten via the XML catalog to a
+ *       {@code classpath:} resource (no network I/O to the original URL).</li>
+ *   <li>Filesystem template roots, then classpath, for non-URL paths.</li>
  * </ol>
- * <p>Anything unresolved throws {@link TransformerException}.</p>
  *
  * <p><strong>Containment guarantee.</strong> For each filesystem root, the resolved path is
  * verified to remain within the root. Both {@code ..} traversal and symlinks pointing outside
@@ -42,9 +49,20 @@ import java.util.Optional;
  * (e.g. {@code vfs:///templates/fa3/ksef_invoice.xsl}) so that Saxon treats them as
  * absolute and does not attempt to resolve them against the JVM working directory.</p>
  *
+ * <p>Remote fetching is contained: a URL resolving outside {@code remoteBaseUrl} ({@code ../}
+ * escapes, authority changes) is rejected and HTTP redirects are not followed.</p>
+ *
  * <p>This class is <strong>internal</strong> and may change between releases.</p>
  */
 public class TemplateResolver implements NonDelegatingURIResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(TemplateResolver.class);
+
+    /** Connect + read timeout used for every HTTP fetch from the remote template server. */
+    private static final int REMOTE_TIMEOUT_MS = 10_000;
+
+    /** Hard cap on the body size of a single remotely fetched stylesheet, to avoid OOM. */
+    private static final int MAX_REMOTE_TEMPLATE_BYTES = 16 * 1024 * 1024;
 
     public static final String HTTP_PREFIX = "http://";
     public static final String HTTPS_PREFIX = "https://";
@@ -55,7 +73,28 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     private final List<Path> roots;
     private final CatalogManager catalogManager;
 
+    /**
+     * When non-null, hrefs that start with this prefix are fetched over HTTP instead of
+     * being looked up in the XML catalog.  All other {@code http(s):} hrefs still use the
+     * catalog (e.g. external XSD files like KodyKrajow).
+     */
+    @Nullable
+    private final String remoteBaseUrl;
+
+    /** Constructs a resolver without remote HTTP support (catalog / classpath only). */
     public TemplateResolver(List<Path> roots) throws TransformerException {
+        this(roots, null);
+    }
+
+    /**
+     * Constructs a resolver with optional remote HTTP support.
+     *
+     * @param roots         ordered filesystem roots searched before the classpath
+     * @param remoteBaseUrl base URL of the remote template server
+     *                      (e.g. {@code "http://localhost:8077/xslt"}).
+     *                      Pass {@code null} to disable remote fetching.
+     */
+    public TemplateResolver(List<Path> roots, @Nullable String remoteBaseUrl) throws TransformerException {
         try {
             this.roots = FilesystemRoots.canonicalize(roots);
         } catch (IOException e) {
@@ -65,17 +104,27 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         config.setFeature(ResolverFeature.CATALOG_FILES,
                 Collections.singletonList("classpath:catalog.xml"));
         this.catalogManager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
+        this.remoteBaseUrl = remoteBaseUrl != null ? remoteBaseUrl.replaceAll("/+$", "") : null;
     }
 
     List<Path> getRoots() {
         return roots;
     }
 
+    @Nullable
+    String getRemoteBaseUrl() {
+        return remoteBaseUrl;
+    }
+
     @Override
     public Source resolve(String href, String base) throws TransformerException {
         Optional<Source> resolved = tryResolve(href, base);
         if (resolved.isPresent()) {
-            return resolved.get();
+            Source source = resolved.get();
+            String systemId = source.getSystemId();
+            log.debug("XSLT: resolved href='{}' base='{}' -> systemId={}",
+                    href, Strings.isEmpty(base) ? "(none)" : base, systemId);
+            return source;
         }
         throw new TransformerException("Template not found: " + href
                 + (Strings.isEmpty(base) ? "" : " (base: " + base + ")"));
@@ -95,8 +144,25 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             throw new TransformerException("Cannot resolve null href");
         }
 
+        // 0. Remote HTTP/HTTPS fetch from the configured template server.
+        //    This takes priority over the catalog so that stylesheets are loaded from
+        //    the server rather than from the bundled classpath copies.
+        if (remoteBaseUrl != null) {
+            // a) Absolute href that belongs to the remote server.
+            if (isUnderRemoteBase(href)) {
+                return Optional.of(fetchFromRemote(requireUnderRemoteBase(normalizeUrl(href), href, base)));
+            }
+            // b) Relative href whose parent stylesheet was fetched from the remote server.
+            //    base will be the HTTP URL of the parent (set as systemId when it was loaded).
+            if (base != null && isUnderRemoteBase(base) && !href.contains(":")) {
+                String resolved = URI.create(base).resolve(href).normalize().toString();
+                return Optional.of(fetchFromRemote(requireUnderRemoteBase(resolved, href, base)));
+            }
+        }
+
         // 1. http: / https: URIs → XML catalog (allowlist); anything not listed throws
         if (href.startsWith(HTTP_PREFIX) || href.startsWith(HTTPS_PREFIX)) {
+            String requestedUri = href;
             URI mapped = catalogManager.lookupURI(href);
             if (mapped == null) {
                 throw new TransformerException("External URI not in catalog: " + href);
@@ -104,6 +170,12 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             if (!"classpath".equals(mapped.getScheme())) {
                 throw new TransformerException("Catalog must map to a classpath: URI, got: " + mapped);
             }
+            log.info(
+                    "XSLT: stylesheet URL '{}' rewritten by classpath catalog to 'classpath:{}' — "
+                            + "bytes are loaded from the classpath/JAR only, never via HTTP from that URL "
+                            + "(having template-server up or down does not change this; remove the catalog rewrite if you want a real HTTP fetch).",
+                    requestedUri,
+                    mapped.getSchemeSpecificPart());
             href = "/" + mapped.getSchemeSpecificPart();
         }
 
@@ -170,6 +242,84 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         Source cp = tryClasspath(relativePath);
         if (cp != null) sources.add(cp);
         return sources;
+    }
+
+    // -----------------------------------------------------------------------
+    // Remote HTTP fetch
+    // -----------------------------------------------------------------------
+
+    /** True if {@code url} equals the base or sits under it as a path segment ({@code base + "/"}). */
+    private boolean isUnderRemoteBase(String url) {
+        return url.equals(remoteBaseUrl) || url.startsWith(remoteBaseUrl + "/");
+    }
+
+    /**
+     * Rejects a resolved URL that escapes the base (e.g. {@code ../} path escape or a
+     * protocol-relative authority change), which raw href/base checks can miss.
+     */
+    private String requireUnderRemoteBase(String resolvedUrl, String href, String base) throws TransformerException {
+        if (!isUnderRemoteBase(resolvedUrl)) {
+            throw new TransformerException("Remote template href escapes the configured base '"
+                    + remoteBaseUrl + "': " + href
+                    + (Strings.isEmpty(base) ? "" : " (base: " + base + ")")
+                    + " resolved to " + resolvedUrl);
+        }
+        return resolvedUrl;
+    }
+
+    private static String normalizeUrl(String url) {
+        return URI.create(url).normalize().toString();
+    }
+
+    /**
+     * Fetches a stylesheet over HTTP. The URL is used as the source systemId so Saxon resolves
+     * relative {@code xsl:import}/{@code include} hrefs against it (re-entering as case 0b).
+     */
+    private Source fetchFromRemote(String url) throws TransformerException {
+        log.debug("XSLT: fetching stylesheet from remote template server: {}", url);
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setConnectTimeout(REMOTE_TIMEOUT_MS);
+            connection.setReadTimeout(REMOTE_TIMEOUT_MS);
+            // Do not follow redirects: a 3xx could send the fetch to an arbitrary host outside
+            // the configured base, defeating the containment check. Treat any non-200 as an error.
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestProperty("Accept", "application/xslt+xml, text/xml, application/xml, */*");
+            connection.setRequestMethod("GET");
+
+            int status = connection.getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new TransformerException(
+                        "Remote template server returned HTTP " + status + " for URL: " + url);
+            }
+
+            // Copy the response body into memory so the connection can be closed cleanly
+            // while Saxon still has an InputStream to read from.
+            byte[] body = readFully(connection.getInputStream());
+            log.debug("XSLT: fetched {} bytes from {}", body.length, url);
+            return new StreamSource(new ByteArrayInputStream(body), url);
+
+        } catch (IOException e) {
+            throw new TransformerException(
+                    "Failed to fetch remote template (server may be down): " + url + " — " + e.getMessage(), e);
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    private static byte[] readFully(InputStream in) throws IOException, TransformerException {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int n;
+        while ((n = in.read(chunk)) != -1) {
+            buf.write(chunk, 0, n);
+            if (buf.size() > MAX_REMOTE_TEMPLATE_BYTES) {
+                throw new TransformerException("Remote template exceeds maximum allowed size of "
+                        + MAX_REMOTE_TEMPLATE_BYTES + " bytes");
+            }
+        }
+        return buf.toByteArray();
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -4,6 +4,7 @@
 package io.alapierre.ksef.fop.internal;
 
 import net.sf.saxon.trans.NonDelegatingURIResolver;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -104,7 +106,49 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         config.setFeature(ResolverFeature.CATALOG_FILES,
                 Collections.singletonList("classpath:catalog.xml"));
         this.catalogManager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
-        this.remoteBaseUrl = remoteBaseUrl != null ? remoteBaseUrl.replaceAll("/+$", "") : null;
+        this.remoteBaseUrl = canonicalizeRemoteBaseUrl(remoteBaseUrl);
+    }
+
+    /**
+     * Validates and normalizes a remote template-server base URL.
+     *
+     * <p>{@code null} or blank (after trim) disables remote fetching. Otherwise the value must
+     * be a syntactically valid {@code http:} / {@code https:} URI with a host; trailing slashes
+     * are stripped.</p>
+     */
+    @Nullable
+    static String canonicalizeRemoteBaseUrl(@Nullable String remoteBaseUrl) throws TransformerException {
+        if (remoteBaseUrl == null) {
+            return null;
+        }
+        String trimmed = remoteBaseUrl.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        URI uri = parseUri(trimmed);
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            throw new TransformerException(
+                    "Remote template base URL must use http or https scheme: " + remoteBaseUrl);
+        }
+        String schemeLower = scheme.toLowerCase(Locale.ROOT);
+        if (!"http".equals(schemeLower) && !"https".equals(schemeLower)) {
+            throw new TransformerException(
+                    "Remote template base URL must use http or https scheme: " + remoteBaseUrl);
+        }
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new TransformerException(
+                    "Remote template base URL must have a host: " + remoteBaseUrl);
+        }
+        return uri.normalize().toString().replaceAll("/+$", "");
+    }
+
+    /**
+     * True if {@code url} equals {@code remoteBaseUrl} or sits under it as a path segment.
+     */
+    public static boolean isUnderRemoteBase(@NotNull String url, @NotNull String remoteBaseUrl) {
+        return url.equals(remoteBaseUrl) || url.startsWith(remoteBaseUrl + "/");
     }
 
     List<Path> getRoots() {
@@ -112,7 +156,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     }
 
     @Nullable
-    String getRemoteBaseUrl() {
+    public String getRemoteBaseUrl() {
         return remoteBaseUrl;
     }
 
@@ -170,7 +214,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             if (!"classpath".equals(mapped.getScheme())) {
                 throw new TransformerException("Catalog must map to a classpath: URI, got: " + mapped);
             }
-            log.info(
+            log.debug(
                     "XSLT: stylesheet URL '{}' rewritten by classpath catalog to 'classpath:{}' — "
                             + "bytes are loaded from the classpath/JAR only, never via HTTP from that URL "
                             + "(having template-server up or down does not change this; remove the catalog rewrite if you want a real HTTP fetch).",
@@ -248,9 +292,8 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     // Remote HTTP fetch
     // -----------------------------------------------------------------------
 
-    /** True if {@code url} equals the base or sits under it as a path segment ({@code base + "/"}). */
     private boolean isUnderRemoteBase(String url) {
-        return url.equals(remoteBaseUrl) || url.startsWith(remoteBaseUrl + "/");
+        return isUnderRemoteBase(url, remoteBaseUrl);
     }
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -5,7 +5,6 @@ package io.alapierre.ksef.fop.internal;
 
 import net.sf.saxon.trans.NonDelegatingURIResolver;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmlresolver.CatalogManager;
@@ -15,20 +14,14 @@ import org.xmlresolver.XMLResolverConfiguration;
 import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 
 /**
@@ -65,12 +58,6 @@ public class TemplateResolver implements NonDelegatingURIResolver {
 
     private static final Logger log = LoggerFactory.getLogger(TemplateResolver.class);
 
-    /** Connect + read timeout used for every HTTP fetch from the remote template server. */
-    private static final int REMOTE_TIMEOUT_MS = 10_000;
-
-    /** Hard cap on the body size of a single remotely fetched stylesheet, to avoid OOM. */
-    private static final int MAX_REMOTE_TEMPLATE_BYTES = 16 * 1024 * 1024;
-
     public static final String HTTP_PREFIX = "http://";
     public static final String HTTPS_PREFIX = "https://";
     private static final String VFS_SCHEME = "vfs";
@@ -102,49 +89,6 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         this.catalogManager = config.getFeature(ResolverFeature.CATALOG_MANAGER);
     }
 
-    /**
-     * Validates and normalizes an HTTP(S) resource-root base URL.
-     */
-    @NotNull
-    static String canonicalizeHttpBaseUrl(@NotNull String baseUrl) throws TransformerException {
-        String trimmed = baseUrl.trim();
-        if (trimmed.isEmpty()) {
-            throw new TransformerException("HTTP resource root must not be blank");
-        }
-        URI uri = parseUri(trimmed);
-        String scheme = uri.getScheme();
-        if (scheme == null) {
-            throw new TransformerException(
-                    "HTTP resource root must use http or https scheme: " + baseUrl);
-        }
-        String schemeLower = scheme.toLowerCase(Locale.ROOT);
-        if (!"http".equals(schemeLower) && !"https".equals(schemeLower)) {
-            throw new TransformerException(
-                    "HTTP resource root must use http or https scheme: " + baseUrl);
-        }
-        String host = uri.getHost();
-        if (host == null || host.isEmpty()) {
-            throw new TransformerException(
-                    "HTTP resource root must have a host: " + baseUrl);
-        }
-        return stripTrailingSlashes(uri.normalize().toString());
-    }
-
-    private static String stripTrailingSlashes(String value) {
-        int end = value.length();
-        while (end > 0 && value.charAt(end - 1) == '/') {
-            end--;
-        }
-        return end == value.length() ? value : value.substring(0, end);
-    }
-
-    /**
-     * True if {@code url} equals {@code httpRoot} or sits under it as a path segment.
-     */
-    public static boolean isUnderRemoteBase(@NotNull String url, @NotNull String httpRoot) {
-        return url.equals(httpRoot) || url.startsWith(httpRoot + "/");
-    }
-
     @NotNull
     List<ResourceRoot> getResourceRoots() {
         return resourceRoots;
@@ -161,7 +105,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
 
     public boolean isUnderAnyHttpRoot(@NotNull String url) {
         for (ResourceRoot root : resourceRoots) {
-            if (root.isUnder(url)) {
+            if (root.contains(url)) {
                 return true;
             }
         }
@@ -200,12 +144,19 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         //    a) Absolute href under an HTTP root.
         //    b) Relative href whose parent stylesheet was fetched from an HTTP root
         //       (base is the HTTP URL of the parent, set as systemId when it was loaded).
-        if (isUnderAnyHttpRoot(href)) {
-            return Optional.of(fetchFromRemote(requireUnderHttpRoot(normalizeUrl(href), href, base)));
+        for (ResourceRoot root : resourceRoots) {
+            Source remote = root.tryFetchAbsolute(href);
+            if (remote != null) {
+                return Optional.of(remote);
+            }
         }
-        if (base != null && isUnderAnyHttpRoot(base) && !href.contains(":")) {
-            String resolved = URI.create(base).resolve(href).normalize().toString();
-            return Optional.of(fetchFromRemote(requireUnderHttpRoot(resolved, href, base)));
+        if (base != null) {
+            for (ResourceRoot root : resourceRoots) {
+                Source remote = root.tryFetchRelativeToBase(href, base);
+                if (remote != null) {
+                    return Optional.of(remote);
+                }
+            }
         }
 
         // 1. http: / https: URIs → XML catalog (allowlist); anything not listed throws
@@ -246,7 +197,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
         }
 
         for (ResourceRoot root : resourceRoots) {
-            Source s = tryResolveAtRoot(root, relativePath);
+            Source s = root.tryResolveRelative(relativePath);
             if (s != null) {
                 return Optional.of(s);
             }
@@ -286,7 +237,7 @@ public class TemplateResolver implements NonDelegatingURIResolver {
 
         List<Source> sources = new ArrayList<>(resourceRoots.size() + 1);
         for (ResourceRoot root : resourceRoots) {
-            Source s = tryResolveAtRoot(root, relativePath);
+            Source s = root.tryResolveRelative(relativePath);
             if (s != null) {
                 sources.add(s);
             }
@@ -300,24 +251,16 @@ public class TemplateResolver implements NonDelegatingURIResolver {
      * Resolves a relative resource to a public URI suitable for FOP external references
      * ({@code file:} or {@code http(s):}).
      */
-    public Optional<String> tryResolvePublicUri(String href) {
+    public Optional<String> tryResolvePublicUri(String href) throws TransformerException {
         if (href == null || href.contains(":")) {
             return Optional.empty();
         }
         String relativePath = href.startsWith("/") ? href.substring(1) : href;
 
         for (ResourceRoot root : resourceRoots) {
-            if (root.isHttp()) {
-                String url = root.resolveUrl(relativePath);
-                if (tryFetchFromRemote(url) != null) {
-                    return Optional.of(url);
-                }
-            } else {
-                Optional<Path> resolved = FilesystemRoots.resolveFileWithin(
-                        root.getFilesystemPath(), relativePath);
-                if (resolved.isPresent()) {
-                    return Optional.of(resolved.get().toUri().toString());
-                }
+            Optional<String> resolved = root.tryResolvePublicUri(relativePath);
+            if (resolved.isPresent()) {
+                return resolved;
             }
         }
 
@@ -326,88 +269,6 @@ public class TemplateResolver implements NonDelegatingURIResolver {
             return Optional.of(classpathUrl.toString());
         }
         return Optional.empty();
-    }
-
-    // -----------------------------------------------------------------------
-    // Remote HTTP fetch
-    // -----------------------------------------------------------------------
-
-    private String requireUnderHttpRoot(String resolvedUrl, String href, String base) throws TransformerException {
-        if (!isUnderAnyHttpRoot(resolvedUrl)) {
-            throw new TransformerException("Remote template href escapes configured HTTP resource root(s): "
-                    + href
-                    + (Strings.isEmpty(base) ? "" : " (base: " + base + ")")
-                    + " resolved to " + resolvedUrl);
-        }
-        return resolvedUrl;
-    }
-
-    private static String normalizeUrl(String url) {
-        return URI.create(url).normalize().toString();
-    }
-
-    @Nullable
-    private Source tryResolveAtRoot(ResourceRoot root, String relativePath) throws TransformerException {
-        if (root.isHttp()) {
-            return tryFetchFromRemote(root.resolveUrl(relativePath));
-        }
-        return tryFilesystem(root.getFilesystemPath(), relativePath);
-    }
-
-    /**
-     * Single GET; returns {@code null} on 404 / network error (used when probing HTTP roots).
-     */
-    @Nullable
-    private Source tryFetchFromRemote(String url) {
-        try {
-            return fetchFromRemote(url);
-        } catch (TransformerException e) {
-            log.debug("Remote resource miss for {}: {}", url, e.getMessage());
-            return null;
-        }
-    }
-
-    private Source fetchFromRemote(String url) throws TransformerException {
-        log.debug("XSLT: fetching resource from remote server: {}", url);
-        HttpURLConnection connection = null;
-        try {
-            connection = (HttpURLConnection) new URL(url).openConnection();
-            connection.setConnectTimeout(REMOTE_TIMEOUT_MS);
-            connection.setReadTimeout(REMOTE_TIMEOUT_MS);
-            connection.setInstanceFollowRedirects(false);
-            connection.setRequestProperty("Accept", "application/xslt+xml, text/xml, application/xml, */*");
-            connection.setRequestMethod("GET");
-
-            int status = connection.getResponseCode();
-            if (status != HttpURLConnection.HTTP_OK) {
-                throw new TransformerException(
-                        "Remote resource server returned HTTP " + status + " for URL: " + url);
-            }
-
-            byte[] body = readFully(connection.getInputStream());
-            log.debug("XSLT: fetched {} bytes from {}", body.length, url);
-            return new StreamSource(new ByteArrayInputStream(body), url);
-
-        } catch (IOException e) {
-            throw new TransformerException(
-                    "Failed to fetch remote resource (server may be down): " + url + " — " + e.getMessage(), e);
-        } finally {
-            if (connection != null) connection.disconnect();
-        }
-    }
-
-    private static byte[] readFully(InputStream in) throws IOException, TransformerException {
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        byte[] chunk = new byte[8192];
-        int n;
-        while ((n = in.read(chunk)) != -1) {
-            buf.write(chunk, 0, n);
-            if (buf.size() > MAX_REMOTE_TEMPLATE_BYTES) {
-                throw new TransformerException("Remote resource exceeds maximum allowed size of "
-                        + MAX_REMOTE_TEMPLATE_BYTES + " bytes");
-            }
-        }
-        return buf.toByteArray();
     }
 
     // -----------------------------------------------------------------------
@@ -470,25 +331,6 @@ public class TemplateResolver implements NonDelegatingURIResolver {
     // -----------------------------------------------------------------------
     // Lookup strategies
     // -----------------------------------------------------------------------
-
-    /**
-     * Tries to load {@code relativePath} from under {@code root}.
-     *
-     * <p>Containment and regular-file check are delegated to
-     * {@link FilesystemRoots#resolveFileWithin(Path, String)}; symlink escapes and
-     * {@code ..} traversal fall through silently to the next lookup step.</p>
-     */
-    private static Source tryFilesystem(Path root, String relativePath) throws TransformerException {
-        Optional<Path> resolved = FilesystemRoots.resolveFileWithin(root, relativePath);
-        if (!resolved.isPresent()) {
-            return null;
-        }
-        try {
-            return new StreamSource(Files.newInputStream(resolved.get()), VFS_PREFIX + relativePath);
-        } catch (IOException e) {
-            throw new TransformerException("File is not accessible: " + resolved.get(), e);
-        }
-    }
 
     /**
      * Tries to load {@code path} as a classpath resource.

--- a/src/main/java/io/alapierre/ksef/fop/internal/UrlResourceRoot.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/UrlResourceRoot.java
@@ -1,0 +1,226 @@
+package io.alapierre.ksef.fop.internal;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * HTTP(S) resource root.
+ */
+final class UrlResourceRoot extends ResourceRoot {
+
+    private static final Logger log = LoggerFactory.getLogger(UrlResourceRoot.class);
+
+    private static final int REMOTE_TIMEOUT_MS = 10_000;
+    private static final int MAX_REMOTE_BYTES = 16 * 1024 * 1024;
+
+    private final URI baseUri;
+
+    private UrlResourceRoot(@NotNull URI baseUri) {
+        this.baseUri = baseUri;
+    }
+
+    static @NotNull UrlResourceRoot canonicalize(@NotNull URI uri) throws TransformerException {
+        URI normalized = parseHttpUri(uri);
+        String host = normalized.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new TransformerException("HTTP resource root must have a host: " + uri);
+        }
+        return new UrlResourceRoot(stripTrailingSlash(normalized));
+    }
+
+    @NotNull
+    URI getBaseUri() {
+        return baseUri;
+    }
+
+    @Override
+    boolean isHttp() {
+        return true;
+    }
+
+    @Override
+    boolean contains(@NotNull String url) {
+        return containsUri(URI.create(url).normalize());
+    }
+
+    @NotNull
+    URI resolveRelative(@NotNull String relativePath) {
+        String path = relativePath.startsWith("/") ? relativePath.substring(1) : relativePath;
+        return baseUri.resolve(path).normalize();
+    }
+
+    @Override
+    @Nullable
+    Source tryFetchAbsolute(@NotNull String url) throws TransformerException {
+        if (!contains(url)) {
+            return null;
+        }
+        return fetch(resolveUri(url));
+    }
+
+    @Override
+    @Nullable
+    Source tryFetchRelativeToBase(@NotNull String href, @NotNull String base) throws TransformerException {
+        if (!contains(base) || href.contains(":")) {
+            return null;
+        }
+        URI resolved = URI.create(base).resolve(href).normalize();
+        if (!containsUri(resolved)) {
+            throw new TransformerException("Remote template href escapes configured HTTP resource root '"
+                    + baseUri + "': " + href + " (base: " + base + ") resolved to " + resolved);
+        }
+        return fetch(resolved);
+    }
+
+    @Override
+    @Nullable
+    Source tryResolveRelative(@NotNull String relativePath) {
+        return tryFetch(resolveRelative(relativePath));
+    }
+
+    @Override
+    @NotNull
+    Optional<String> tryResolvePublicUri(@NotNull String relativePath) {
+        URI url = resolveRelative(relativePath);
+        return tryFetch(url) != null ? Optional.of(url.toString()) : Optional.empty();
+    }
+
+    @Nullable
+    Source tryFetch(@NotNull URI url) {
+        try {
+            return fetch(url);
+        } catch (TransformerException e) {
+            log.debug("Remote resource miss for {}: {}", url, e.getMessage());
+            return null;
+        }
+    }
+
+    @NotNull
+    Source fetch(@NotNull URI url) throws TransformerException {
+        String urlString = url.toString();
+        log.debug("XSLT: fetching resource from remote server: {}", urlString);
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(urlString).openConnection();
+            connection.setConnectTimeout(REMOTE_TIMEOUT_MS);
+            connection.setReadTimeout(REMOTE_TIMEOUT_MS);
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestProperty("Accept", "application/xslt+xml, text/xml, application/xml, */*");
+            connection.setRequestMethod("GET");
+
+            int status = connection.getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new TransformerException(
+                        "Remote resource server returned HTTP " + status + " for URL: " + urlString);
+            }
+
+            byte[] body = readFully(connection.getInputStream());
+            log.debug("XSLT: fetched {} bytes from {}", body.length, urlString);
+            return new StreamSource(new ByteArrayInputStream(body), urlString);
+
+        } catch (IOException e) {
+            throw new TransformerException(
+                    "Failed to fetch remote resource (server may be down): " + urlString
+                            + " — " + e.getMessage(), e);
+        } finally {
+            if (connection != null) connection.disconnect();
+        }
+    }
+
+    private boolean containsUri(@NotNull URI url) {
+        URI normalized = url.normalize();
+        if (normalized.equals(baseUri)) {
+            return true;
+        }
+        String base = baseUri.toString();
+        String target = normalized.toString();
+        return target.startsWith(base + "/");
+    }
+
+    @NotNull
+    private static URI resolveUri(@NotNull String url) {
+        return URI.create(url).normalize();
+    }
+
+    @NotNull
+    private static URI parseHttpUri(@NotNull URI uri) throws TransformerException {
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            throw new TransformerException(
+                    "HTTP resource root must use http or https scheme: " + uri);
+        }
+        String schemeLower = scheme.toLowerCase(Locale.ROOT);
+        if (!"http".equals(schemeLower) && !"https".equals(schemeLower)) {
+            throw new TransformerException(
+                    "HTTP resource root must use http or https scheme: " + uri);
+        }
+        try {
+            return new URI(schemeLower, uri.getUserInfo(), uri.getHost(), uri.getPort(),
+                    uri.getPath(), uri.getQuery(), uri.getFragment()).normalize();
+        } catch (URISyntaxException e) {
+            throw new TransformerException("Invalid HTTP resource root: " + uri, e);
+        }
+    }
+
+    @NotNull
+    private static URI stripTrailingSlash(@NotNull URI uri) {
+        String s = uri.toString();
+        int end = s.length();
+        while (end > 0 && s.charAt(end - 1) == '/') {
+            end--;
+        }
+        if (end == s.length()) {
+            return uri;
+        }
+        return URI.create(s.substring(0, end));
+    }
+
+    private static byte[] readFully(InputStream in) throws IOException, TransformerException {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int n;
+        while ((n = in.read(chunk)) != -1) {
+            buf.write(chunk, 0, n);
+            if (buf.size() > MAX_REMOTE_BYTES) {
+                throw new TransformerException("Remote resource exceeds maximum allowed size of "
+                        + MAX_REMOTE_BYTES + " bytes");
+            }
+        }
+        return buf.toByteArray();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UrlResourceRoot)) return false;
+        UrlResourceRoot that = (UrlResourceRoot) o;
+        return Objects.equals(baseUri, that.baseUri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseUri);
+    }
+
+    @Override
+    public String toString() {
+        return "UrlResourceRoot{" + baseUri + "}";
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/internal/XmlFactories.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/XmlFactories.java
@@ -163,14 +163,13 @@ public final class XmlFactories {
         public boolean equals(Object o) {
             if (!(o instanceof TemplateKey)) return false;
             TemplateKey that = (TemplateKey) o;
-            return Objects.equals(resolver.getRoots(), that.resolver.getRoots())
-                    && Objects.equals(resolver.getRemoteBaseUrl(), that.resolver.getRemoteBaseUrl())
+            return Objects.equals(resolver.getResourceRoots(), that.resolver.getResourceRoots())
                     && Objects.equals(templatePath, that.templatePath);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(resolver.getRoots(), resolver.getRemoteBaseUrl(), templatePath);
+            return Objects.hash(resolver.getResourceRoots(), templatePath);
         }
     }
 }

--- a/src/main/java/io/alapierre/ksef/fop/internal/XmlFactories.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/XmlFactories.java
@@ -55,9 +55,6 @@ public final class XmlFactories {
      */
     private static final Configuration SAXON_CONFIGURATION;
 
-    /**
-     * Precompiled templates
-     */
     private static final Map<TemplateKey, Templates> TEMPLATE_CACHE = new ConcurrentHashMap<>();
 
     static {
@@ -124,19 +121,16 @@ public final class XmlFactories {
         try {
             TransformerFactory factory = createTransformerFactory();
             factory.setURIResolver(key.resolver);
-            return factory.newTemplates(key.resolver.resolve(key.templatePath, null));
+            javax.xml.transform.Source stylesheet = key.resolver.resolve(key.templatePath, null);
+            return factory.newTemplates(stylesheet);
         } catch (TransformerException e) {
             throw new RuntimeException(e);
         }
     }
 
     /**
-     * Returns a compiled {@link Templates} for {@code templatePath}, resolved against the given
-     * {@code roots} (then the classpath) by a {@link TemplateResolver}.
-     *
-     * <p><strong>Caching:</strong> Compiled templates are cached indefinitely, keyed by
-     * {@code (roots, templatePath)}. Once a template has been compiled, later changes to the
-     * underlying stylesheet files are <em>not</em> picked up for the lifetime of the JVM.</p>
+     * Returns a compiled {@link Templates} for {@code templatePath}, resolved by a
+     * {@link TemplateResolver}. Cached per {@code (roots, remoteBaseUrl, templatePath)}.
      */
     public static Templates getTemplate(TemplateResolver resolver, String templatePath) throws TransformerException {
         TemplateKey key = new TemplateKey(resolver, templatePath);
@@ -169,12 +163,14 @@ public final class XmlFactories {
         public boolean equals(Object o) {
             if (!(o instanceof TemplateKey)) return false;
             TemplateKey that = (TemplateKey) o;
-            return Objects.equals(resolver.getRoots(), that.resolver.getRoots()) && Objects.equals(templatePath, that.templatePath);
+            return Objects.equals(resolver.getRoots(), that.resolver.getRoots())
+                    && Objects.equals(resolver.getRemoteBaseUrl(), that.resolver.getRemoteBaseUrl())
+                    && Objects.equals(templatePath, that.templatePath);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(resolver.getRoots(), templatePath);
+            return Objects.hash(resolver.getRoots(), resolver.getRemoteBaseUrl(), templatePath);
         }
     }
 }

--- a/src/test/java/io/alapierre/ksef/fop/CustomTemplateOverrideTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/CustomTemplateOverrideTest.java
@@ -91,7 +91,7 @@ class CustomTemplateOverrideTest {
                 .ksefNumber("FS-KSEF-NUMBER")
                 .templatePath("templates/custom/custom_invoice.xsl")
                 .customProperties(Collections.singletonMap("customPropertyDemo", "HELLO-FS-PROPERTY"))
-                .templateRoot(tempDir)
+                .resourceRoot(tempDir.toUri())
                 .build();
 
         String text = generateAndExtractText(params);
@@ -112,7 +112,7 @@ class CustomTemplateOverrideTest {
                 .schema(InvoiceSchema.FA3_1_0_E)
                 .ksefNumber("SHADOW-TEST")
                 .templatePath("templates/custom/custom_invoice.xsl")
-                .templateRoot(tempDir)
+                .resourceRoot(tempDir.toUri())
                 .build();
 
         String text = generateAndExtractText(params);

--- a/src/test/java/io/alapierre/ksef/fop/RemoteTemplateConfigValidationTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/RemoteTemplateConfigValidationTest.java
@@ -5,40 +5,41 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Early-fail checks for {@code remoteTemplateBaseUrl} / HTTP {@code templatePath} consistency.
+ * Early-fail checks for HTTP {@code resourceRoot} / {@code templatePath} consistency.
  */
 class RemoteTemplateConfigValidationTest {
 
     private static final String TEMPLATE_SERVER_BASE = "http://localhost:8077/xslt";
 
     @Test
-    void invalidRemoteBaseUrlFailsBeforeNetworkFetch() {
+    void invalidHttpResourceRootFailsBeforeNetworkFetch() {
         InvoiceGenerationParams params = InvoiceGenerationParams.builder()
                 .schema(InvoiceSchema.FA3_1_0_E)
                 .templatePath(TEMPLATE_SERVER_BASE + "/ksef_invoice")
-                .remoteTemplateBaseUrl("not-a-valid-url")
+                .resourceRoot(URI.create("ftp://localhost/xslt"))
                 .build();
 
         assertThatThrownBy(() -> generate(params))
                 .isInstanceOf(javax.xml.transform.TransformerException.class)
-                .hasMessageContaining("http or https");
+                .hasMessageContaining("http(s) URL");
     }
 
     @Test
-    void httpTemplatePathOutsideRemoteBaseFailsBeforeNetworkFetch() {
+    void httpTemplatePathOutsideResourceRootFailsBeforeNetworkFetch() {
         InvoiceGenerationParams params = InvoiceGenerationParams.builder()
                 .schema(InvoiceSchema.FA3_1_0_E)
                 .templatePath("http://other-host:8077/xslt/ksef_invoice")
-                .remoteTemplateBaseUrl(TEMPLATE_SERVER_BASE)
+                .resourceRoot(URI.create(TEMPLATE_SERVER_BASE))
                 .build();
 
         assertThatThrownBy(() -> generate(params))
                 .isInstanceOf(javax.xml.transform.TransformerException.class)
-                .hasMessageContaining("not under remoteTemplateBaseUrl");
+                .hasMessageContaining("not under any configured HTTP resource root");
     }
 
     private static void generate(InvoiceGenerationParams params) throws Exception {

--- a/src/test/java/io/alapierre/ksef/fop/RemoteTemplateConfigValidationTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/RemoteTemplateConfigValidationTest.java
@@ -1,0 +1,56 @@
+package io.alapierre.ksef.fop;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Early-fail checks for {@code remoteTemplateBaseUrl} / HTTP {@code templatePath} consistency.
+ */
+class RemoteTemplateConfigValidationTest {
+
+    private static final String TEMPLATE_SERVER_BASE = "http://localhost:8077/xslt";
+
+    @Test
+    void invalidRemoteBaseUrlFailsBeforeNetworkFetch() {
+        InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                .schema(InvoiceSchema.FA3_1_0_E)
+                .templatePath(TEMPLATE_SERVER_BASE + "/ksef_invoice")
+                .remoteTemplateBaseUrl("not-a-valid-url")
+                .build();
+
+        assertThatThrownBy(() -> generate(params))
+                .isInstanceOf(javax.xml.transform.TransformerException.class)
+                .hasMessageContaining("http or https");
+    }
+
+    @Test
+    void httpTemplatePathOutsideRemoteBaseFailsBeforeNetworkFetch() {
+        InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                .schema(InvoiceSchema.FA3_1_0_E)
+                .templatePath("http://other-host:8077/xslt/ksef_invoice")
+                .remoteTemplateBaseUrl(TEMPLATE_SERVER_BASE)
+                .build();
+
+        assertThatThrownBy(() -> generate(params))
+                .isInstanceOf(javax.xml.transform.TransformerException.class)
+                .hasMessageContaining("not under remoteTemplateBaseUrl");
+    }
+
+    private static void generate(InvoiceGenerationParams params) throws Exception {
+        try (InputStream fopCfg = resource("fop.xconf");
+             InputStream invoiceIs = resource("faktury/fa3/podstawowa/FA_3_Przyklad_1.xml")) {
+            PdfGenerator generator = new PdfGenerator(fopCfg);
+            byte[] invoiceXml = IOUtils.toByteArray(invoiceIs);
+            generator.generateInvoice(invoiceXml, params, new ByteArrayOutputStream());
+        }
+    }
+
+    private static InputStream resource(String path) {
+        return RemoteTemplateConfigValidationTest.class.getClassLoader().getResourceAsStream(path);
+    }
+}

--- a/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
@@ -276,12 +276,6 @@ class TranslationServiceTest {
     }
 
     @Test
-    void toServeFilename_stripsI18nPrefix() {
-        assertEquals("labels.xml", TranslationService.toServeFilename("i18n/labels.xml"));
-        assertEquals("labels_en.xml", TranslationService.toServeFilename("i18n/labels_en.xml"));
-    }
-
-    @Test
     void getTranslation_withNonHttpRemoteEntryUrl_shouldUseClasspath() throws TransformerException {
         TranslationService svc = new TranslationService(
                 new TemplateResolver(Collections.emptyList()),

--- a/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
@@ -10,6 +10,7 @@ import org.w3c.dom.NodeList;
 
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -284,7 +285,7 @@ class TranslationServiceTest {
     }
 
     @Test
-    void getTranslation_withHttpEntryUrlButNoRemoteBase_shouldUseClasspath() throws TransformerException {
+    void getTranslation_withHttpEntryUrlButNoHttpResourceRoot_shouldUseClasspath() throws TransformerException {
         TranslationService svc = new TranslationService(
                 new TemplateResolver(Collections.emptyList()),
                 "http://localhost:8077/xslt/ksef_invoice");
@@ -296,7 +297,11 @@ class TranslationServiceTest {
     // -----------------------------------------------------------------------
 
     private static TranslationService serviceWithRoots(Path... roots) throws TransformerException {
-        return new TranslationService(new TemplateResolver(Arrays.asList(roots)));
+        URI[] uris = new URI[roots.length];
+        for (int i = 0; i < roots.length; i++) {
+            uris[i] = roots[i].toUri();
+        }
+        return new TranslationService(new TemplateResolver(Arrays.asList(uris)));
     }
 
     /**

--- a/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/i18n/TranslationServiceTest.java
@@ -272,6 +272,29 @@ class TranslationServiceTest {
     @Test
     void constructor_shouldRejectNullResolver() {
         assertThrows(NullPointerException.class, () -> new TranslationService(null));
+        assertThrows(NullPointerException.class, () -> new TranslationService(null, "http://host/t.xsl"));
+    }
+
+    @Test
+    void toServeFilename_stripsI18nPrefix() {
+        assertEquals("labels.xml", TranslationService.toServeFilename("i18n/labels.xml"));
+        assertEquals("labels_en.xml", TranslationService.toServeFilename("i18n/labels_en.xml"));
+    }
+
+    @Test
+    void getTranslation_withNonHttpRemoteEntryUrl_shouldUseClasspath() throws TransformerException {
+        TranslationService svc = new TranslationService(
+                new TemplateResolver(Collections.emptyList()),
+                "templates/fa3/ksef_invoice.xsl");
+        assertEquals("Numer faktury", svc.getTranslation("pl", "invoice.number"));
+    }
+
+    @Test
+    void getTranslation_withHttpEntryUrlButNoRemoteBase_shouldUseClasspath() throws TransformerException {
+        TranslationService svc = new TranslationService(
+                new TemplateResolver(Collections.emptyList()),
+                "http://localhost:8077/xslt/ksef_invoice");
+        assertEquals("Numer faktury", svc.getTranslation("pl", "invoice.number"));
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
@@ -171,12 +171,12 @@ class TemplateResolverTest {
     }
 
     @Test
-    void isUnderRemoteBaseDetectsPrefixAndExactMatch() {
-        String base = "http://localhost:8077/xslt";
-        assertThat(TemplateResolver.isUnderRemoteBase(base, base)).isTrue();
-        assertThat(TemplateResolver.isUnderRemoteBase(base + "/ksef_invoice", base)).isTrue();
-        assertThat(TemplateResolver.isUnderRemoteBase("http://evil.example/xslt/ksef_invoice", base)).isFalse();
-        assertThat(TemplateResolver.isUnderRemoteBase("http://localhost:8077/xsltx", base)).isFalse();
+    void urlResourceRootDetectsPrefixAndExactMatch() throws Exception {
+        UrlResourceRoot root = UrlResourceRoot.canonicalize(URI.create("http://localhost:8077/xslt"));
+        assertThat(root.contains("http://localhost:8077/xslt")).isTrue();
+        assertThat(root.contains("http://localhost:8077/xslt/ksef_invoice")).isTrue();
+        assertThat(root.contains("http://evil.example/xslt/ksef_invoice")).isFalse();
+        assertThat(root.contains("http://localhost:8077/xsltx")).isFalse();
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
@@ -13,6 +13,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,7 +34,7 @@ class TemplateResolverTest {
         Path file = root.resolve("my-template.xsl");
         write(file, "<xsl/>");
 
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
         Source source = resolver.resolve("my-template.xsl", "");
 
         assertThat(source).isNotNull();
@@ -45,7 +46,7 @@ class TemplateResolverTest {
         Path file = root2.resolve("found-in-second.xsl");
         write(file, "<xsl/>");
 
-        TemplateResolver resolver = new TemplateResolver(Arrays.asList(root1, root2));
+        TemplateResolver resolver = new TemplateResolver(Arrays.asList(root1.toUri(), root2.toUri()));
         Source source = resolver.resolve("found-in-second.xsl", "");
 
         assertThat(source).isNotNull();
@@ -57,7 +58,7 @@ class TemplateResolverTest {
         write(root1.resolve("template.xsl"), "root1");
         write(root2.resolve("template.xsl"), "root2");
 
-        TemplateResolver resolver = new TemplateResolver(Arrays.asList(root1, root2));
+        TemplateResolver resolver = new TemplateResolver(Arrays.asList(root1.toUri(), root2.toUri()));
         Source source = resolver.resolve("template.xsl", "");
 
         assertThat(source).isInstanceOf(StreamSource.class);
@@ -94,7 +95,7 @@ class TemplateResolverTest {
         Path file = root.resolve("my template.xsl");
         write(file, "<xsl/>");
 
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
         Source source = resolver.resolve("my template.xsl", "");
 
         assertThat(source).isNotNull();
@@ -122,7 +123,7 @@ class TemplateResolverTest {
         write(subDir.resolve("included.xsl"), "<included/>");
         write(root.resolve("templates").resolve("shared.xsl"), "<shared/>");
 
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
 
         // First: entry point
         Source main = resolver.resolve("templates/custom/main.xsl", "");
@@ -140,32 +141,32 @@ class TemplateResolverTest {
     }
 
     // -----------------------------------------------------------------------
-    // Remote template base URL validation
+    // HTTP resource root validation
     // -----------------------------------------------------------------------
 
     @Test
-    void blankRemoteBaseUrlDisablesRemoteFetching(@TempDir Path root) throws Exception {
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root), "   ");
-        assertThat(resolver.getRemoteBaseUrl()).isNull();
+    void filesystemOnlyResolverHasNoHttpRoots(@TempDir Path root) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
+        assertThat(resolver.isUnderAnyHttpRoot("http://localhost:8077/xslt/ksef_invoice")).isFalse();
     }
 
     @Test
-    void remoteBaseUrlTrailingSlashesAreStripped(@TempDir Path root) throws Exception {
+    void httpResourceRootTrailingSlashesAreStripped(@TempDir Path root) throws Exception {
         TemplateResolver resolver = new TemplateResolver(
-                Collections.singletonList(root), "http://localhost:8077/xslt///");
-        assertThat(resolver.getRemoteBaseUrl()).isEqualTo("http://localhost:8077/xslt");
+                Arrays.asList(root.toUri(), URI.create("http://localhost:8077/xslt///")));
+        assertThat(resolver.isUnderAnyHttpRoot("http://localhost:8077/xslt/ksef_invoice")).isTrue();
+        assertThat(resolver.isUnderAnyHttpRoot("http://localhost:8077/xsltx/ksef_invoice")).isFalse();
     }
 
     @ParameterizedTest
     @ValueSource(strings = {
             "ftp://localhost/xslt",
-            "not-a-url",
             "http:///xslt",
             "https:///only-path"
     })
-    void invalidRemoteBaseUrlThrowsOnConstruction(String remoteBaseUrl, @TempDir Path root) {
+    void invalidHttpResourceRootThrowsOnConstruction(String httpRoot, @TempDir Path root) {
         assertThatThrownBy(() ->
-                new TemplateResolver(Collections.singletonList(root), remoteBaseUrl))
+                new TemplateResolver(Arrays.asList(root.toUri(), URI.create(httpRoot))))
                 .isInstanceOf(TransformerException.class);
     }
 
@@ -224,7 +225,7 @@ class TemplateResolverTest {
 
     @Test
     void dotDotTraversalIsRejected(@TempDir Path root) throws Exception {
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
 
         assertThatThrownBy(() ->
                 resolver.resolve("../../etc/passwd", null))
@@ -234,7 +235,7 @@ class TemplateResolverTest {
     @Test
     void dotDotInBaseDoesNotEscapeRoot(@TempDir Path root) throws Exception {
         // Trying to escape via a crafted base
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
 
         assertThatThrownBy(() ->
                 resolver.resolve("../../../etc/passwd", "vfs:///templates/fa3/ksef_invoice.xsl"))
@@ -252,7 +253,7 @@ class TemplateResolverTest {
         Path link = root.resolve("evil.xsl");
         Files.createSymbolicLink(link, target);
 
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
 
         assertThatThrownBy(() ->
                 resolver.resolve("evil.xsl", ""))
@@ -266,7 +267,7 @@ class TemplateResolverTest {
     @ParameterizedTest
     @ValueSource(strings = {"", "vfs:///templates"})
     void missingTemplateThrows(String base, @TempDir Path root) throws Exception {
-        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root));
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root.toUri()));
 
         assertThatThrownBy(() ->
                 resolver.resolve("nonexistent.xsl", base))

--- a/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
@@ -140,6 +140,45 @@ class TemplateResolverTest {
     }
 
     // -----------------------------------------------------------------------
+    // Remote template base URL validation
+    // -----------------------------------------------------------------------
+
+    @Test
+    void blankRemoteBaseUrlDisablesRemoteFetching(@TempDir Path root) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(Collections.singletonList(root), "   ");
+        assertThat(resolver.getRemoteBaseUrl()).isNull();
+    }
+
+    @Test
+    void remoteBaseUrlTrailingSlashesAreStripped(@TempDir Path root) throws Exception {
+        TemplateResolver resolver = new TemplateResolver(
+                Collections.singletonList(root), "http://localhost:8077/xslt///");
+        assertThat(resolver.getRemoteBaseUrl()).isEqualTo("http://localhost:8077/xslt");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ftp://localhost/xslt",
+            "not-a-url",
+            "http:///xslt",
+            "https:///only-path"
+    })
+    void invalidRemoteBaseUrlThrowsOnConstruction(String remoteBaseUrl, @TempDir Path root) {
+        assertThatThrownBy(() ->
+                new TemplateResolver(Collections.singletonList(root), remoteBaseUrl))
+                .isInstanceOf(TransformerException.class);
+    }
+
+    @Test
+    void isUnderRemoteBaseDetectsPrefixAndExactMatch() {
+        String base = "http://localhost:8077/xslt";
+        assertThat(TemplateResolver.isUnderRemoteBase(base, base)).isTrue();
+        assertThat(TemplateResolver.isUnderRemoteBase(base + "/ksef_invoice", base)).isTrue();
+        assertThat(TemplateResolver.isUnderRemoteBase("http://evil.example/xslt/ksef_invoice", base)).isFalse();
+        assertThat(TemplateResolver.isUnderRemoteBase("http://localhost:8077/xsltx", base)).isFalse();
+    }
+
+    // -----------------------------------------------------------------------
     // Catalog / HTTP URIs
     // -----------------------------------------------------------------------
 

--- a/src/test/resources/catalog.xml
+++ b/src/test/resources/catalog.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <!-- External URLs resolve to a resource file with or without leading '/' -->
     <uri name="http://crd.gov.pl/xml/schematy/dziedzinowe/mf/2022/01/05/eD/DefinicjeTypy/KodyKrajow_v10-0E.xsd"
          uri="xsd/KodyKrajow_v10-0E.xsd"/>
     <uri name="https://example.com/KodyKrajow_v10-0E.xsd"
          uri="/xsd/KodyKrajow_v10-0E.xsd"/>
+    <!-- HttpTemplatePathInvoiceTest: catalog-backed HTTP templatePath (no live fetch) -->
+    <uri name="http://localhost:8077/xslt/ksef_invoice"
+         uri="classpath:templates/fa3/ksef_invoice.xsl"/>
+    <uri name="http://localhost:8077/xslt/ksef_invoice.xsl"
+         uri="classpath:templates/fa3/ksef_invoice.xsl"/>
 </catalog>


### PR DESCRIPTION
## Summary

- Add optional `remoteTemplateBaseUrl` to `InvoiceGenerationParams` and `UpoGenerationParams`, wired through `PdfGenerator` into `TemplateResolver`.
- When set, stylesheets and relative `xsl:import` / `xsl:include` hrefs that resolve under that base are fetched over HTTP from a trusted template server; all other `http(s):` URIs still go through the existing XML catalog allowlist (no change to default classpath/filesystem resolution).
- Harden remote fetching: URLs must stay within the configured base after normalization (`../` escapes and protocol-relative authority changes are rejected), HTTP redirects are not followed, and response bodies are capped at 16 MB.
- Update `XmlFactories` template cache key to include `remoteBaseUrl`, and document catalog-based `templatePath` usage in the readme.

Backward compatible: when `remoteTemplateBaseUrl` is unset, behavior is unchanged.

## Usage

```java
InvoiceGenerationParams.builder()
    .schema(InvoiceSchema.FA3_1_0_E)
    .templatePath("http://template-server.tst/xslt/6891152920/ksef_invoice")
    .remoteTemplateBaseUrl("http://template-server.tst/xslt")
    .build();
```

With `remoteTemplateBaseUrl` set, the URL above is fetched from the template server. Without it, an `http(s):` `templatePath` must be listed in `classpath:catalog.xml` and is resolved to a bundled classpath resource (no network I/O).

## Security notes

- `remoteTemplateBaseUrl` and `templatePath` remain the caller's responsibility — point them only at trusted infrastructure.
- Remote fetches are scoped to the configured base; redirects are disabled.
- Template content itself is not validated by this library before being passed to Saxon (same as for filesystem/classpath templates).