### PR TITLE
Remove Lombok in favour of explicit code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <!-- Dependency versions -->
         <annotations.version>24.1.0</annotations.version>
         <assertj.version>3.27.7</assertj.version>
+        <equalsverifier.version>3.16.1</equalsverifier.version>
         <pdfbox.version>3.0.7</pdfbox.version>
         <slf4j.version>2.0.17</slf4j.version>
         <zxing.version>3.5.4</zxing.version>
@@ -393,6 +394,13 @@
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-assertj3</artifactId>
             <version>${xmlunit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>${equalsverifier.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <maven.enforcer.plugin.version>3.6.2</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.5.4</maven.surefire.plugin.version>
         <maven.release-plugin.version>3.3.1</maven.release-plugin.version>
+        <japicmp.plugin.version>0.23.1</japicmp.plugin.version>
     </properties>
 
     <build>
@@ -143,6 +144,34 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.2.2</version>
+            </plugin>
+
+            <!--
+              Checks backward binary compatibility of the public API against the previous release.
+              The baseline (the latest non-SNAPSHOT version published in the repository) is resolved
+              automatically, so no configuration needs to be bumped at release time.
+            -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <version>${japicmp.plugin.version}</version>
+                <configuration>
+                    <parameter>
+                        <onlyModified>true</onlyModified>
+                        <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                        <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
+                        <ignoreMissingClasses>true</ignoreMissingClasses>
+                    </parameter>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>backward-compatibility</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>cmp</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <maven.enforcer.plugin.version>3.6.2</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.5.4</maven.surefire.plugin.version>
         <maven.release-plugin.version>3.3.1</maven.release-plugin.version>
-        <japicmp.plugin.version>0.23.1</japicmp.plugin.version>
+        <japicmp.plugin.version>0.26.1</japicmp.plugin.version>
     </properties>
 
     <build>
@@ -161,6 +161,23 @@
                         <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                         <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                         <ignoreMissingClasses>true</ignoreMissingClasses>
+                        <!--
+                          Accepts the builder classes being made `final` in this release.
+
+                          Making a class `final` only breaks consumers that could actually subclass it,
+                          i.e. classes that expose a public or protected constructor.
+                          Our builders only have a package-private constructor, so they don't fall into this category.
+
+                          Remove this rule after 1.2.25 is released.
+                        -->
+                        <overrideCompatibilityChangeParameters>
+                            <overrideCompatibilityChangeParameter>
+                                <compatibilityChange>CLASS_NOW_NOT_EXTENDABLE</compatibilityChange>
+                                <binaryCompatible>true</binaryCompatible>
+                                <sourceCompatible>true</sourceCompatible>
+                                <semanticVersionLevel>PATCH</semanticVersionLevel>
+                            </overrideCompatibilityChangeParameter>
+                        </overrideCompatibilityChangeParameters>
                     </parameter>
                 </configuration>
                 <executions>
@@ -299,12 +316,6 @@
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>fop-core</artifactId>
             <version>2.11</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>1.18.42</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -140,7 +140,7 @@ public class InvoiceGenerationParams {
         this.customProperties = builder.customProperties;
         this.language = builder.language == null ? Language.PL : builder.language;
         this.languageLocale = builder.languageLocale;
-        this.templateRoots = builder.templateRoots == null
+        this.templateRoots = builder.templateRoots.isEmpty()
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(builder.templateRoots));
     }
@@ -396,7 +396,7 @@ public class InvoiceGenerationParams {
         private Map<String, Object> customProperties;
         private Language language = Language.PL;
         private String languageLocale;
-        private ArrayList<Path> templateRoots;
+        private final ArrayList<Path> templateRoots = new ArrayList<>();
 
         InvoiceGenerationParamsBuilder() {
         }
@@ -471,21 +471,19 @@ public class InvoiceGenerationParams {
         }
 
         public InvoiceGenerationParamsBuilder templateRoot(Path templateRoot) {
-            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
             this.templateRoots.add(templateRoot);
             return this;
         }
 
         public InvoiceGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
             if (templateRoots != null) {
-                if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
                 this.templateRoots.addAll(templateRoots);
             }
             return this;
         }
 
         public InvoiceGenerationParamsBuilder clearTemplateRoots() {
-            if (this.templateRoots != null) this.templateRoots.clear();
+            this.templateRoots.clear();
             return this;
         }
 

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -45,47 +45,16 @@ public class InvoiceGenerationParams {
     @Nullable
     private InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest;
 
-    /**
-     * Optional classpath-relative path to a custom XSLT invoice template.
-     * <p>
-     * Security note: This value must reference a trusted stylesheet available on the application's classpath.
-     * The library does not validate where this path comes from; callers are responsible for ensuring that
-     * untrusted users cannot control this value or the underlying XSLT content.
-     */
     @Nullable
     private String templatePath;
 
-    /**
-     * Optional template-specific XSLT parameters forwarded to the transformer.
-     * <p>
-     * Security note: Values in this map are passed directly as XSLT parameters.
-     * The library does not validate parameter names or values; callers are responsible for ensuring that
-     * untrusted users cannot control this map when rendering trusted templates.
-     */
     private Map<String, Object> customProperties;
 
-    /**
-     * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
-     * language tag (e.g. {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}) and is not
-     * limited to the values defined by this enum. Kept for backward compatibility.
-     * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
-     */
     private Language language;
 
-    /**
-     * Optional BCP&nbsp;47 language tag used to select the label file for translations
-     * (e.g. {@code "en"}, {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}). Both
-     * {@code _} and {@code -} separators are accepted. Unknown tags fall back to the
-     * default language ({@link Language#DEFAULT_LANGUAGE_TAG}) without raising an error.
-     *
-     * <p>When set, this value takes precedence over the deprecated {@link #language} enum.</p>
-     */
     @Nullable
     private String languageLocale;
 
-    /**
-     * Ordered list of filesystem directories searched before the classpath when resolving templates.
-     */
     private final List<Path> templateRoots;
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -432,7 +432,7 @@ public class InvoiceGenerationParams {
         }
 
         public InvoiceGenerationParamsBuilder schema(@NotNull InvoiceSchema schema) {
-            this.schema = Objects.requireNonNull(schema, "schema");
+            this.schema = schema;
             return this;
         }
 
@@ -477,9 +477,10 @@ public class InvoiceGenerationParams {
         }
 
         public InvoiceGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
-            Objects.requireNonNull(templateRoots, "template roots cannot be null");
-            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
-            this.templateRoots.addAll(templateRoots);
+            if (templateRoots != null) {
+                if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
+                this.templateRoots.addAll(templateRoots);
+            }
             return this;
         }
 

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -86,7 +86,7 @@ public class InvoiceGenerationParams {
     /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
-    private List<Path> templateRoots;
+    private final List<Path> templateRoots;
 
     /**
      * @deprecated use the builder instead.

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -60,7 +59,7 @@ public class InvoiceGenerationParams {
      * The library does not validate parameter names or values; callers are responsible for ensuring that
      * untrusted users cannot control this map when rendering trusted templates.
      */
-    private Map<String, Object> customProperties = new HashMap<>();
+    private Map<String, Object> customProperties;
 
     /**
      * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
@@ -92,18 +91,7 @@ public class InvoiceGenerationParams {
      */
     @Deprecated
     public InvoiceGenerationParams() {
-        this(null,
-                null,
-                null,
-                null,
-                null,
-                false,
-                InvoiceSchema.FA3_1_0_E,
-                null,
-                null,
-                null,
-                null,
-                null);
+        this(builder().schema(InvoiceSchema.FA3_1_0_E));
     }
 
     /**
@@ -123,55 +111,38 @@ public class InvoiceGenerationParams {
             @Nullable String templatePath,
             Map<String, Object> customProperties,
             Language language) {
-        this(verificationLink,
-                logo,
-                logoUri,
-                currencyDate,
-                issuerUser,
-                showCorrectionDifferences,
-                schema,
-                ksefNumber,
-                invoiceQRCodeGeneratorRequest,
-                templatePath,
-                customProperties,
-                language,
-                null,
-                null);
+        this(builder()
+                .verificationLink(verificationLink)
+                .logo(logo)
+                .logoUri(logoUri)
+                .currencyDate(currencyDate)
+                .issuerUser(issuerUser)
+                .showCorrectionDifferences(showCorrectionDifferences)
+                .schema(schema)
+                .ksefNumber(ksefNumber)
+                .invoiceQRCodeGeneratorRequest(invoiceQRCodeGeneratorRequest)
+                .templatePath(templatePath)
+                .customProperties(customProperties)
+                .language(language));
     }
 
-    private InvoiceGenerationParams(
-            @Nullable String verificationLink,
-            byte[] logo,
-            URI logoUri,
-            @Nullable LocalDate currencyDate,
-            @Nullable String issuerUser,
-            boolean showCorrectionDifferences,
-            @NotNull InvoiceSchema schema,
-            @Nullable String ksefNumber,
-            @Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest,
-            @Nullable String templatePath,
-            Map<String, Object> customProperties,
-            Language language,
-            @Nullable String languageLocale,
-            List<Path> templateRoots) {
-        this.verificationLink = verificationLink;
-        this.logo = logo;
-        this.logoUri = logoUri;
-        this.currencyDate = currencyDate;
-        this.issuerUser = issuerUser;
-        this.showCorrectionDifferences = showCorrectionDifferences;
-        this.schema = Objects.requireNonNull(schema, "schema");
-        this.ksefNumber = ksefNumber;
-        this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
-        this.templatePath = templatePath;
-        this.customProperties = customProperties == null
-                ? Collections.emptyMap()
-                : Collections.unmodifiableMap(customProperties);
-        this.language = language == null ? Language.PL : language;
-        this.languageLocale = languageLocale;
-        this.templateRoots = templateRoots == null
+    private InvoiceGenerationParams(InvoiceGenerationParamsBuilder builder) {
+        this.verificationLink = builder.verificationLink;
+        this.logo = builder.logo;
+        this.logoUri = builder.logoUri;
+        this.currencyDate = builder.currencyDate;
+        this.issuerUser = builder.issuerUser;
+        this.showCorrectionDifferences = builder.showCorrectionDifferences;
+        this.schema = Objects.requireNonNull(builder.schema, "schema");
+        this.ksefNumber = builder.ksefNumber;
+        this.invoiceQRCodeGeneratorRequest = builder.invoiceQRCodeGeneratorRequest;
+        this.templatePath = builder.templatePath;
+        this.customProperties = builder.customProperties;
+        this.language = builder.language == null ? Language.PL : builder.language;
+        this.languageLocale = builder.languageLocale;
+        this.templateRoots = builder.templateRoots == null
                 ? Collections.emptyList()
-                : Collections.unmodifiableList(new ArrayList<>(templateRoots));
+                : Collections.unmodifiableList(new ArrayList<>(builder.templateRoots));
     }
 
     @Nullable
@@ -278,6 +249,7 @@ public class InvoiceGenerationParams {
      * The library does not validate parameter names or values; callers are responsible for ensuring that
      * untrusted users cannot control this map when rendering trusted templates.
      */
+    @Nullable
     public Map<String, Object> getCustomProperties() {
         return customProperties;
     }
@@ -421,7 +393,7 @@ public class InvoiceGenerationParams {
         private String ksefNumber;
         private InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest;
         private String templatePath;
-        private Map<String, Object> customProperties = new HashMap<>();
+        private Map<String, Object> customProperties;
         private Language language = Language.PL;
         private String languageLocale;
         private ArrayList<Path> templateRoots;
@@ -505,9 +477,7 @@ public class InvoiceGenerationParams {
         }
 
         public InvoiceGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
-            if (templateRoots == null) {
-                throw new NullPointerException("templateRoots cannot be null");
-            }
+            Objects.requireNonNull(templateRoots, "template roots cannot be null");
             if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
             this.templateRoots.addAll(templateRoots);
             return this;
@@ -519,9 +489,7 @@ public class InvoiceGenerationParams {
         }
 
         public InvoiceGenerationParams build() {
-            return new InvoiceGenerationParams(verificationLink, logo, logoUri, currencyDate, issuerUser,
-                    showCorrectionDifferences, schema, ksefNumber, invoiceQRCodeGeneratorRequest, templatePath,
-                    customProperties, language, languageLocale, templateRoots);
+            return new InvoiceGenerationParams(this);
         }
 
         @Override

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -1,28 +1,20 @@
 package io.alapierre.ksef.fop;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class InvoiceGenerationParams {
     @Nullable
     private String verificationLink;
@@ -68,7 +60,6 @@ public class InvoiceGenerationParams {
      * The library does not validate parameter names or values; callers are responsible for ensuring that
      * untrusted users cannot control this map when rendering trusted templates.
      */
-    @Builder.Default
     private Map<String, Object> customProperties = new HashMap<>();
 
     /**
@@ -78,7 +69,6 @@ public class InvoiceGenerationParams {
      * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
      */
     @Deprecated
-    @Builder.Default
     private Language language = Language.PL;
 
     /**
@@ -95,10 +85,26 @@ public class InvoiceGenerationParams {
     /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
-    @Singular("templateRoot")
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
     private List<Path> templateRoots;
+
+    /**
+     * @deprecated use the builder instead.
+     */
+    @Deprecated
+    public InvoiceGenerationParams() {
+        this(null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                InvoiceSchema.FA3_1_0_E,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
 
     /**
      * @deprecated use the builder instead.
@@ -117,28 +123,210 @@ public class InvoiceGenerationParams {
             @Nullable String templatePath,
             Map<String, Object> customProperties,
             Language language) {
+        this(verificationLink,
+                logo,
+                logoUri,
+                currencyDate,
+                issuerUser,
+                showCorrectionDifferences,
+                schema,
+                ksefNumber,
+                invoiceQRCodeGeneratorRequest,
+                templatePath,
+                customProperties,
+                language,
+                null,
+                null);
+    }
+
+    private InvoiceGenerationParams(
+            @Nullable String verificationLink,
+            byte[] logo,
+            URI logoUri,
+            @Nullable LocalDate currencyDate,
+            @Nullable String issuerUser,
+            boolean showCorrectionDifferences,
+            @NotNull InvoiceSchema schema,
+            @Nullable String ksefNumber,
+            @Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest,
+            @Nullable String templatePath,
+            Map<String, Object> customProperties,
+            Language language,
+            @Nullable String languageLocale,
+            List<Path> templateRoots) {
         this.verificationLink = verificationLink;
         this.logo = logo;
         this.logoUri = logoUri;
         this.currencyDate = currencyDate;
         this.issuerUser = issuerUser;
         this.showCorrectionDifferences = showCorrectionDifferences;
-        this.schema = schema;
+        this.schema = Objects.requireNonNull(schema, "schema");
         this.ksefNumber = ksefNumber;
         this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
         this.templatePath = templatePath;
-        this.customProperties = customProperties != null ? customProperties : new HashMap<>();
-        this.language = language != null ? language : Language.PL;
-        this.languageLocale = null;
-        this.templateRoots = Collections.emptyList();
+        this.customProperties = customProperties == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(customProperties);
+        this.language = language == null ? Language.PL : language;
+        this.languageLocale = languageLocale;
+        this.templateRoots = templateRoots == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(templateRoots));
+    }
+
+    @Nullable
+    public String getVerificationLink() {
+        return verificationLink;
+    }
+
+    public void setVerificationLink(@Nullable String verificationLink) {
+        this.verificationLink = verificationLink;
+    }
+
+    public byte[] getLogo() {
+        return logo;
+    }
+
+    public void setLogo(byte[] logo) {
+        this.logo = logo;
+    }
+
+    public URI getLogoUri() {
+        return logoUri;
+    }
+
+    public void setLogoUri(URI logoUri) {
+        this.logoUri = logoUri;
+    }
+
+    @Nullable
+    public LocalDate getCurrencyDate() {
+        return currencyDate;
+    }
+
+    public void setCurrencyDate(@Nullable LocalDate currencyDate) {
+        this.currencyDate = currencyDate;
+    }
+
+    @Nullable
+    public String getIssuerUser() {
+        return issuerUser;
+    }
+
+    public void setIssuerUser(@Nullable String issuerUser) {
+        this.issuerUser = issuerUser;
+    }
+
+    public boolean isShowCorrectionDifferences() {
+        return showCorrectionDifferences;
+    }
+
+    public void setShowCorrectionDifferences(boolean showCorrectionDifferences) {
+        this.showCorrectionDifferences = showCorrectionDifferences;
+    }
+
+    @NotNull
+    public InvoiceSchema getSchema() {
+        return schema;
+    }
+
+    public void setSchema(@NotNull InvoiceSchema schema) {
+        this.schema = Objects.requireNonNull(schema, "schema");
+    }
+
+    /**
+     * KSeF Number if provided, OFFLINE label will shown otherwise
+     */
+    @Nullable
+    public String getKsefNumber() {
+        return ksefNumber;
+    }
+
+    public void setKsefNumber(@Nullable String ksefNumber) {
+        this.ksefNumber = ksefNumber;
+    }
+
+    @Nullable
+    public InvoiceQRCodeGeneratorRequest getInvoiceQRCodeGeneratorRequest() {
+        return invoiceQRCodeGeneratorRequest;
+    }
+
+    public void setInvoiceQRCodeGeneratorRequest(@Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest) {
+        this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
+    }
+
+    /**
+     * Optional classpath-relative path to a custom XSLT invoice template.
+     * <p>
+     * Security note: This value must reference a trusted stylesheet available on the application's classpath.
+     * The library does not validate where this path comes from; callers are responsible for ensuring that
+     * untrusted users cannot control this value or the underlying XSLT content.
+     */
+    @Nullable
+    public String getTemplatePath() {
+        return templatePath;
+    }
+
+    public void setTemplatePath(@Nullable String templatePath) {
+        this.templatePath = templatePath;
+    }
+
+    /**
+     * Optional template-specific XSLT parameters forwarded to the transformer.
+     * <p>
+     * Security note: Values in this map are passed directly as XSLT parameters.
+     * The library does not validate parameter names or values; callers are responsible for ensuring that
+     * untrusted users cannot control this map when rendering trusted templates.
+     */
+    public Map<String, Object> getCustomProperties() {
+        return customProperties;
+    }
+
+    public void setCustomProperties(Map<String, Object> customProperties) {
+        this.customProperties = customProperties;
+    }
+
+    /**
+     * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
+     * language tag (e.g. {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}) and is not
+     * limited to the values defined by this enum. Kept for backward compatibility.
+     * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
+     */
+    @Deprecated
+    public Language getLanguage() {
+        return language;
+    }
+
+    /**
+     * @deprecated use {@link #languageLocale} instead.
+     */
+    @Deprecated
+    public void setLanguage(Language language) {
+        this.language = language;
+    }
+
+    /**
+     * Optional BCP&nbsp;47 language tag used to select the label file for translations
+     * (e.g. {@code "en"}, {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}). Both
+     * {@code _} and {@code -} separators are accepted. Unknown tags fall back to the
+     * default language ({@link Language#DEFAULT_LANGUAGE_TAG}) without raising an error.
+     *
+     * <p>When set, this value takes precedence over the deprecated {@link #language} enum.</p>
+     */
+    @Nullable
+    public String getLanguageLocale() {
+        return languageLocale;
+    }
+
+    public void setLanguageLocale(@Nullable String languageLocale) {
+        this.languageLocale = languageLocale;
     }
 
     /**
      * Returns an unmodifiable view of the configured filesystem template roots.
      */
     public List<Path> getTemplateRoots() {
-        if (templateRoots == null) return Collections.emptyList();
-        return Collections.unmodifiableList(templateRoots);
+        return templateRoots;
     }
 
     /**
@@ -160,5 +348,198 @@ public class InvoiceGenerationParams {
         }
         if (language != null) return language.getCode();
         return Language.DEFAULT_LANGUAGE_TAG;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o instanceof InvoiceGenerationParams) {
+            InvoiceGenerationParams other = (InvoiceGenerationParams) o;
+            return other.canEqual(this)
+                    && showCorrectionDifferences == other.showCorrectionDifferences
+                    && Arrays.equals(logo, other.logo)
+                    && Objects.equals(verificationLink, other.verificationLink)
+                    && Objects.equals(logoUri, other.logoUri)
+                    && Objects.equals(currencyDate, other.currencyDate)
+                    && Objects.equals(issuerUser, other.issuerUser)
+                    && Objects.equals(schema, other.schema)
+                    && Objects.equals(ksefNumber, other.ksefNumber)
+                    && Objects.equals(invoiceQRCodeGeneratorRequest, other.invoiceQRCodeGeneratorRequest)
+                    && Objects.equals(templatePath, other.templatePath)
+                    && Objects.equals(customProperties, other.customProperties)
+                    && Objects.equals(language, other.language)
+                    && Objects.equals(languageLocale, other.languageLocale)
+                    && Objects.equals(getTemplateRoots(), other.getTemplateRoots());
+        }
+        return false;
+    }
+
+    protected boolean canEqual(Object other) {
+        return other instanceof InvoiceGenerationParams;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(verificationLink, logoUri, currencyDate, issuerUser,
+                showCorrectionDifferences, schema, ksefNumber, invoiceQRCodeGeneratorRequest,
+                templatePath, customProperties, language, languageLocale, getTemplateRoots());
+        result = 31 * result + Arrays.hashCode(logo);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "InvoiceGenerationParams(verificationLink=" + verificationLink
+                + ", logo=" + Arrays.toString(logo)
+                + ", logoUri=" + logoUri
+                + ", currencyDate=" + currencyDate
+                + ", issuerUser=" + issuerUser
+                + ", showCorrectionDifferences=" + showCorrectionDifferences
+                + ", schema=" + schema
+                + ", ksefNumber=" + ksefNumber
+                + ", invoiceQRCodeGeneratorRequest=" + invoiceQRCodeGeneratorRequest
+                + ", templatePath=" + templatePath
+                + ", customProperties=" + customProperties
+                + ", language=" + language
+                + ", languageLocale=" + languageLocale
+                + ", templateRoots=" + getTemplateRoots() + ")";
+    }
+
+    public static InvoiceGenerationParamsBuilder builder() {
+        return new InvoiceGenerationParamsBuilder();
+    }
+
+    public static final class InvoiceGenerationParamsBuilder {
+
+        private String verificationLink;
+        private byte[] logo;
+        private URI logoUri;
+        private LocalDate currencyDate;
+        private String issuerUser;
+        private boolean showCorrectionDifferences;
+        private InvoiceSchema schema;
+        private String ksefNumber;
+        private InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest;
+        private String templatePath;
+        private Map<String, Object> customProperties = new HashMap<>();
+        private Language language = Language.PL;
+        private String languageLocale;
+        private ArrayList<Path> templateRoots;
+
+        InvoiceGenerationParamsBuilder() {
+        }
+
+        public InvoiceGenerationParamsBuilder verificationLink(@Nullable String verificationLink) {
+            this.verificationLink = verificationLink;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder logo(byte[] logo) {
+            this.logo = logo;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder logoUri(URI logoUri) {
+            this.logoUri = logoUri;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder currencyDate(@Nullable LocalDate currencyDate) {
+            this.currencyDate = currencyDate;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder issuerUser(@Nullable String issuerUser) {
+            this.issuerUser = issuerUser;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder showCorrectionDifferences(boolean showCorrectionDifferences) {
+            this.showCorrectionDifferences = showCorrectionDifferences;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder schema(@NotNull InvoiceSchema schema) {
+            this.schema = Objects.requireNonNull(schema, "schema");
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder ksefNumber(@Nullable String ksefNumber) {
+            this.ksefNumber = ksefNumber;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder invoiceQRCodeGeneratorRequest(@Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest) {
+            this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder templatePath(@Nullable String templatePath) {
+            this.templatePath = templatePath;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder customProperties(Map<String, Object> customProperties) {
+            this.customProperties = customProperties;
+            return this;
+        }
+
+        /**
+         * @deprecated use {@link #languageLocale(String)} instead.
+         */
+        @Deprecated
+        public InvoiceGenerationParamsBuilder language(Language language) {
+            this.language = language;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder languageLocale(@Nullable String languageLocale) {
+            this.languageLocale = languageLocale;
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder templateRoot(Path templateRoot) {
+            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
+            this.templateRoots.add(templateRoot);
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
+            if (templateRoots == null) {
+                throw new NullPointerException("templateRoots cannot be null");
+            }
+            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
+            this.templateRoots.addAll(templateRoots);
+            return this;
+        }
+
+        public InvoiceGenerationParamsBuilder clearTemplateRoots() {
+            if (this.templateRoots != null) this.templateRoots.clear();
+            return this;
+        }
+
+        public InvoiceGenerationParams build() {
+            return new InvoiceGenerationParams(verificationLink, logo, logoUri, currencyDate, issuerUser,
+                    showCorrectionDifferences, schema, ksefNumber, invoiceQRCodeGeneratorRequest, templatePath,
+                    customProperties, language, languageLocale, templateRoots);
+        }
+
+        @Override
+        public String toString() {
+            return "InvoiceGenerationParams.InvoiceGenerationParamsBuilder(verificationLink=" + verificationLink
+                    + ", logo=" + Arrays.toString(logo)
+                    + ", logoUri=" + logoUri
+                    + ", currencyDate=" + currencyDate
+                    + ", issuerUser=" + issuerUser
+                    + ", showCorrectionDifferences=" + showCorrectionDifferences
+                    + ", schema=" + schema
+                    + ", ksefNumber=" + ksefNumber
+                    + ", invoiceQRCodeGeneratorRequest=" + invoiceQRCodeGeneratorRequest
+                    + ", templatePath=" + templatePath
+                    + ", customProperties=" + customProperties
+                    + ", language=" + language
+                    + ", languageLocale=" + languageLocale
+                    + ", templateRoots=" + templateRoots + ")";
+        }
     }
 }

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -70,8 +70,7 @@ public class InvoiceGenerationParams {
      * limited to the values defined by this enum. Kept for backward compatibility.
      * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
      */
-    @Deprecated
-    private Language language = Language.PL;
+    private Language language;
 
     /**
      * Optional BCP&nbsp;47 language tag used to select the label file for translations

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceGenerationParams.java
@@ -14,6 +14,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Parameters controlling how a KSeF invoice is rendered to PDF.
+ */
 public class InvoiceGenerationParams {
     @Nullable
     private String verificationLink;
@@ -95,6 +98,18 @@ public class InvoiceGenerationParams {
     }
 
     /**
+     * @param verificationLink the KSeF verification link
+     * @param logo the raster logo image bytes
+     * @param logoUri the logo image URI
+     * @param currencyDate the exchange-rate date
+     * @param issuerUser the issuing user label
+     * @param showCorrectionDifferences whether to show correction differences
+     * @param schema the invoice schema to render
+     * @param ksefNumber the KSeF number, or {@code null} for an offline label
+     * @param invoiceQRCodeGeneratorRequest the QR code generation request
+     * @param templatePath the classpath-relative custom template path
+     * @param customProperties the template-specific XSLT parameters
+     * @param language the label language
      * @deprecated use the builder instead.
      */
     @Deprecated
@@ -145,83 +160,152 @@ public class InvoiceGenerationParams {
                 : Collections.unmodifiableList(new ArrayList<>(builder.templateRoots));
     }
 
+    /**
+     * Returns the KSeF verification link.
+     * @return the verification link, or {@code null} if unset
+     */
     @Nullable
     public String getVerificationLink() {
         return verificationLink;
     }
 
+    /**
+     * Sets the KSeF verification link.
+     * @param verificationLink the verification link, or {@code null} to unset
+     */
     public void setVerificationLink(@Nullable String verificationLink) {
         this.verificationLink = verificationLink;
     }
 
+    /**
+     * Returns the raster logo image bytes.
+     * @return the logo bytes
+     */
     public byte[] getLogo() {
         return logo;
     }
 
+    /**
+     * Sets the raster logo image bytes.
+     * @param logo the logo bytes
+     */
     public void setLogo(byte[] logo) {
         this.logo = logo;
     }
 
+    /**
+     * Returns the logo image URI.
+     * @return the logo URI
+     */
     public URI getLogoUri() {
         return logoUri;
     }
 
+    /**
+     * Sets the logo image URI.
+     * @param logoUri the logo URI
+     */
     public void setLogoUri(URI logoUri) {
         this.logoUri = logoUri;
     }
 
+    /**
+     * Returns the exchange-rate date.
+     * @return the currency date, or {@code null} if unset
+     */
     @Nullable
     public LocalDate getCurrencyDate() {
         return currencyDate;
     }
 
+    /**
+     * Sets the exchange-rate date.
+     * @param currencyDate the currency date, or {@code null} to unset
+     */
     public void setCurrencyDate(@Nullable LocalDate currencyDate) {
         this.currencyDate = currencyDate;
     }
 
+    /**
+     * Returns the issuing user label.
+     * @return the issuer user, or {@code null} if unset
+     */
     @Nullable
     public String getIssuerUser() {
         return issuerUser;
     }
 
+    /**
+     * Sets the issuing user label.
+     * @param issuerUser the issuer user, or {@code null} to unset
+     */
     public void setIssuerUser(@Nullable String issuerUser) {
         this.issuerUser = issuerUser;
     }
 
+    /**
+     * Tells whether correction differences are shown.
+     * @return {@code true} if correction differences are shown
+     */
     public boolean isShowCorrectionDifferences() {
         return showCorrectionDifferences;
     }
 
+    /**
+     * Sets whether correction differences are shown.
+     * @param showCorrectionDifferences {@code true} to show correction differences
+     */
     public void setShowCorrectionDifferences(boolean showCorrectionDifferences) {
         this.showCorrectionDifferences = showCorrectionDifferences;
     }
 
+    /**
+     * Returns the invoice schema to render.
+     * @return the invoice schema
+     */
     @NotNull
     public InvoiceSchema getSchema() {
         return schema;
     }
 
+    /**
+     * Sets the invoice schema to render.
+     * @param schema the invoice schema, never {@code null}
+     */
     public void setSchema(@NotNull InvoiceSchema schema) {
         this.schema = Objects.requireNonNull(schema, "schema");
     }
 
     /**
      * KSeF Number if provided, OFFLINE label will shown otherwise
+     * @return the KSeF number, or {@code null} for an offline label
      */
     @Nullable
     public String getKsefNumber() {
         return ksefNumber;
     }
 
+    /**
+     * Sets the KSeF number.
+     * @param ksefNumber the KSeF number, or {@code null} for an offline label
+     */
     public void setKsefNumber(@Nullable String ksefNumber) {
         this.ksefNumber = ksefNumber;
     }
 
+    /**
+     * Returns the QR code generation request.
+     * @return the QR code request, or {@code null} if unset
+     */
     @Nullable
     public InvoiceQRCodeGeneratorRequest getInvoiceQRCodeGeneratorRequest() {
         return invoiceQRCodeGeneratorRequest;
     }
 
+    /**
+     * Sets the QR code generation request.
+     * @param invoiceQRCodeGeneratorRequest the QR code request, or {@code null} to unset
+     */
     public void setInvoiceQRCodeGeneratorRequest(@Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest) {
         this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
     }
@@ -232,12 +316,17 @@ public class InvoiceGenerationParams {
      * Security note: This value must reference a trusted stylesheet available on the application's classpath.
      * The library does not validate where this path comes from; callers are responsible for ensuring that
      * untrusted users cannot control this value or the underlying XSLT content.
+     * @return the custom template path, or {@code null} to use the schema default
      */
     @Nullable
     public String getTemplatePath() {
         return templatePath;
     }
 
+    /**
+     * Sets the classpath-relative path to a custom XSLT invoice template.
+     * @param templatePath the custom template path, or {@code null} to use the schema default
+     */
     public void setTemplatePath(@Nullable String templatePath) {
         this.templatePath = templatePath;
     }
@@ -248,17 +337,23 @@ public class InvoiceGenerationParams {
      * Security note: Values in this map are passed directly as XSLT parameters.
      * The library does not validate parameter names or values; callers are responsible for ensuring that
      * untrusted users cannot control this map when rendering trusted templates.
+     * @return the custom XSLT parameters, or {@code null} if unset
      */
     @Nullable
     public Map<String, Object> getCustomProperties() {
         return customProperties;
     }
 
+    /**
+     * Sets the template-specific XSLT parameters forwarded to the transformer.
+     * @param customProperties the custom XSLT parameters
+     */
     public void setCustomProperties(Map<String, Object> customProperties) {
         this.customProperties = customProperties;
     }
 
     /**
+     * @return the label language
      * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
      * language tag (e.g. {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}) and is not
      * limited to the values defined by this enum. Kept for backward compatibility.
@@ -270,6 +365,7 @@ public class InvoiceGenerationParams {
     }
 
     /**
+     * @param language the label language
      * @deprecated use {@link #languageLocale} instead.
      */
     @Deprecated
@@ -284,18 +380,25 @@ public class InvoiceGenerationParams {
      * default language ({@link Language#DEFAULT_LANGUAGE_TAG}) without raising an error.
      *
      * <p>When set, this value takes precedence over the deprecated {@link #language} enum.</p>
+     *
+     * @return the BCP&nbsp;47 language tag, or {@code null} if unset
      */
     @Nullable
     public String getLanguageLocale() {
         return languageLocale;
     }
 
+    /**
+     * Sets the BCP&nbsp;47 language tag used to select the label file.
+     * @param languageLocale the BCP&nbsp;47 language tag, or {@code null} to unset
+     */
     public void setLanguageLocale(@Nullable String languageLocale) {
         this.languageLocale = languageLocale;
     }
 
     /**
      * Returns an unmodifiable view of the configured filesystem template roots.
+     * @return the template roots, never {@code null}
      */
     public List<Path> getTemplateRoots() {
         return templateRoots;
@@ -311,6 +414,8 @@ public class InvoiceGenerationParams {
      *
      * <p>This is the single source of truth consumed by the rendering pipeline;
      * callers should not inspect {@link #languageLocale} or {@link #language} directly.</p>
+     *
+     * @return the resolved BCP&nbsp;47 language tag, never {@code null}
      */
     @NotNull
     public String resolveLanguageTag() {
@@ -346,6 +451,11 @@ public class InvoiceGenerationParams {
         return false;
     }
 
+    /**
+     * Tells whether {@code other} may be compared for equality with this instance.
+     * @param other the object to test
+     * @return {@code true} if {@code other} is an {@code InvoiceGenerationParams}
+     */
     protected boolean canEqual(Object other) {
         return other instanceof InvoiceGenerationParams;
     }
@@ -377,10 +487,17 @@ public class InvoiceGenerationParams {
                 + ", templateRoots=" + getTemplateRoots() + ")";
     }
 
+    /**
+     * Creates a new builder for {@link InvoiceGenerationParams}.
+     * @return a fresh builder
+     */
     public static InvoiceGenerationParamsBuilder builder() {
         return new InvoiceGenerationParamsBuilder();
     }
 
+    /**
+     * Fluent builder for {@link InvoiceGenerationParams}.
+     */
     public static final class InvoiceGenerationParamsBuilder {
 
         private String verificationLink;
@@ -401,62 +518,119 @@ public class InvoiceGenerationParams {
         InvoiceGenerationParamsBuilder() {
         }
 
+        /**
+         * Sets the KSeF verification link.
+         * @param verificationLink the verification link, or {@code null} to unset
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder verificationLink(@Nullable String verificationLink) {
             this.verificationLink = verificationLink;
             return this;
         }
 
+        /**
+         * Sets the raster logo image bytes.
+         * @param logo the logo bytes
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder logo(byte[] logo) {
             this.logo = logo;
             return this;
         }
 
+        /**
+         * Sets the logo image URI.
+         * @param logoUri the logo URI
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder logoUri(URI logoUri) {
             this.logoUri = logoUri;
             return this;
         }
 
+        /**
+         * Sets the exchange-rate date.
+         * @param currencyDate the currency date, or {@code null} to unset
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder currencyDate(@Nullable LocalDate currencyDate) {
             this.currencyDate = currencyDate;
             return this;
         }
 
+        /**
+         * Sets the issuing user label.
+         * @param issuerUser the issuer user, or {@code null} to unset
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder issuerUser(@Nullable String issuerUser) {
             this.issuerUser = issuerUser;
             return this;
         }
 
+        /**
+         * Sets whether correction differences are shown.
+         * @param showCorrectionDifferences {@code true} to show correction differences
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder showCorrectionDifferences(boolean showCorrectionDifferences) {
             this.showCorrectionDifferences = showCorrectionDifferences;
             return this;
         }
 
+        /**
+         * Sets the invoice schema to render.
+         * @param schema the invoice schema
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder schema(@NotNull InvoiceSchema schema) {
             this.schema = schema;
             return this;
         }
 
+        /**
+         * Sets the KSeF number.
+         * @param ksefNumber the KSeF number, or {@code null} for an offline label
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder ksefNumber(@Nullable String ksefNumber) {
             this.ksefNumber = ksefNumber;
             return this;
         }
 
+        /**
+         * Sets the QR code generation request.
+         * @param invoiceQRCodeGeneratorRequest the QR code request, or {@code null} to unset
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder invoiceQRCodeGeneratorRequest(@Nullable InvoiceQRCodeGeneratorRequest invoiceQRCodeGeneratorRequest) {
             this.invoiceQRCodeGeneratorRequest = invoiceQRCodeGeneratorRequest;
             return this;
         }
 
+        /**
+         * Sets the classpath-relative path to a custom XSLT invoice template.
+         * @param templatePath the custom template path, or {@code null} to use the schema default
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder templatePath(@Nullable String templatePath) {
             this.templatePath = templatePath;
             return this;
         }
 
+        /**
+         * Sets the template-specific XSLT parameters forwarded to the transformer.
+         * @param customProperties the custom XSLT parameters
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder customProperties(Map<String, Object> customProperties) {
             this.customProperties = customProperties;
             return this;
         }
 
         /**
+         * @param language the label language
+         * @return this builder
          * @deprecated use {@link #languageLocale(String)} instead.
          */
         @Deprecated
@@ -465,16 +639,32 @@ public class InvoiceGenerationParams {
             return this;
         }
 
+        /**
+         * Sets the BCP&nbsp;47 language tag used to select the label file.
+         * @param languageLocale the BCP&nbsp;47 language tag, or {@code null} to unset
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder languageLocale(@Nullable String languageLocale) {
             this.languageLocale = languageLocale;
             return this;
         }
 
+        /**
+         * Appends a single filesystem template root searched before the classpath.
+         * @param templateRoot the directory to append
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder templateRoot(Path templateRoot) {
             this.templateRoots.add(templateRoot);
             return this;
         }
 
+        /**
+         * Appends a collection of filesystem template roots searched before the classpath.
+         * A {@code null} collection is ignored.
+         * @param templateRoots the directories to append, or {@code null}
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
             if (templateRoots != null) {
                 this.templateRoots.addAll(templateRoots);
@@ -482,11 +672,19 @@ public class InvoiceGenerationParams {
             return this;
         }
 
+        /**
+         * Removes all template roots accumulated so far.
+         * @return this builder
+         */
         public InvoiceGenerationParamsBuilder clearTemplateRoots() {
             this.templateRoots.clear();
             return this;
         }
 
+        /**
+         * Builds an immutable {@link InvoiceGenerationParams} from this builder's state.
+         * @return the configured parameters
+         */
         public InvoiceGenerationParams build() {
             return new InvoiceGenerationParams(this);
         }

--- a/src/main/java/io/alapierre/ksef/fop/InvoicePdfConfig.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoicePdfConfig.java
@@ -1,17 +1,8 @@
 package io.alapierre.ksef.fop;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
  * The {@code InvoicePdfConfig} class represents the configuration settings for generating PDF invoices.
  */
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class InvoicePdfConfig {
 
     /**
@@ -27,4 +18,90 @@ public class InvoicePdfConfig {
      * If {@code false}, unit prices will be displayed with 2 decimal places. (default)
      */
     private boolean useExtendedPriceDecimalPlaces = false;
+
+    public InvoicePdfConfig() {
+    }
+
+    public InvoicePdfConfig(boolean showFooter, boolean useExtendedPriceDecimalPlaces) {
+        this.showFooter = showFooter;
+        this.useExtendedPriceDecimalPlaces = useExtendedPriceDecimalPlaces;
+    }
+
+    public boolean isShowFooter() {
+        return showFooter;
+    }
+
+    public void setShowFooter(boolean showFooter) {
+        this.showFooter = showFooter;
+    }
+
+    public boolean isUseExtendedPriceDecimalPlaces() {
+        return useExtendedPriceDecimalPlaces;
+    }
+
+    public void setUseExtendedPriceDecimalPlaces(boolean useExtendedPriceDecimalPlaces) {
+        this.useExtendedPriceDecimalPlaces = useExtendedPriceDecimalPlaces;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o instanceof InvoicePdfConfig) {
+            InvoicePdfConfig other = (InvoicePdfConfig) o;
+            return other.canEqual(this)
+                    && showFooter == other.showFooter
+                    && useExtendedPriceDecimalPlaces == other.useExtendedPriceDecimalPlaces;
+        }
+        return false;
+    }
+
+    protected boolean canEqual(Object other) {
+        return other instanceof InvoicePdfConfig;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Boolean.hashCode(showFooter);
+        result = 31 * result + Boolean.hashCode(useExtendedPriceDecimalPlaces);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "InvoicePdfConfig(showFooter=" + showFooter
+                + ", useExtendedPriceDecimalPlaces=" + useExtendedPriceDecimalPlaces + ")";
+    }
+
+    public static InvoicePdfConfigBuilder builder() {
+        return new InvoicePdfConfigBuilder();
+    }
+
+    public static final class InvoicePdfConfigBuilder {
+
+        private boolean showFooter;
+        private boolean useExtendedPriceDecimalPlaces;
+
+        InvoicePdfConfigBuilder() {
+        }
+
+        public InvoicePdfConfigBuilder showFooter(boolean showFooter) {
+            this.showFooter = showFooter;
+            return this;
+        }
+
+        public InvoicePdfConfigBuilder useExtendedPriceDecimalPlaces(boolean useExtendedPriceDecimalPlaces) {
+            this.useExtendedPriceDecimalPlaces = useExtendedPriceDecimalPlaces;
+            return this;
+        }
+
+        public InvoicePdfConfig build() {
+            return new InvoicePdfConfig(showFooter, useExtendedPriceDecimalPlaces);
+        }
+
+        @Override
+        public String toString() {
+            return "InvoicePdfConfig.InvoicePdfConfigBuilder(showFooter=" + showFooter
+                    + ", useExtendedPriceDecimalPlaces=" + useExtendedPriceDecimalPlaces + ")";
+        }
+    }
 }

--- a/src/main/java/io/alapierre/ksef/fop/InvoiceQRCodeGeneratorRequest.java
+++ b/src/main/java/io/alapierre/ksef/fop/InvoiceQRCodeGeneratorRequest.java
@@ -1,12 +1,12 @@
 package io.alapierre.ksef.fop;
 
 import io.alapierre.ksef.fop.qr.enums.ContextIdentifierType;
-import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.security.PrivateKey;
 import java.time.LocalDate;
+import java.util.Objects;
 
 /**
  * Request for generating QR codes for KSeF invoices.
@@ -20,7 +20,6 @@ import java.time.LocalDate;
  * 
  * @see <a href="https://github.com/CIRFMF/ksef-docs/blob/main/kody-qr.md">KSeF QR Codes Documentation</a>
  */
-@Data
 public class InvoiceQRCodeGeneratorRequest {
 
     @Nullable
@@ -175,4 +174,136 @@ public class InvoiceQRCodeGeneratorRequest {
 
     private InvoiceQRCodeGeneratorRequest() {}
 
+    @Nullable
+    public String getEnvironmentUrl() {
+        return environmentUrl;
+    }
+
+    public void setEnvironmentUrl(@Nullable String environmentUrl) {
+        this.environmentUrl = environmentUrl;
+    }
+
+    @Nullable
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    public void setIdentifier(@Nullable String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Nullable
+    public LocalDate getIssueDate() {
+        return issueDate;
+    }
+
+    public void setIssueDate(@Nullable LocalDate issueDate) {
+        this.issueDate = issueDate;
+    }
+
+    @Nullable
+    public ContextIdentifierType getCtxType() {
+        return ctxType;
+    }
+
+    public void setCtxType(@Nullable ContextIdentifierType ctxType) {
+        this.ctxType = ctxType;
+    }
+
+    @Nullable
+    public String getCtxValue() {
+        return ctxValue;
+    }
+
+    public void setCtxValue(@Nullable String ctxValue) {
+        this.ctxValue = ctxValue;
+    }
+
+    @Nullable
+    public String getCertSerial() {
+        return certSerial;
+    }
+
+    public void setCertSerial(@Nullable String certSerial) {
+        this.certSerial = certSerial;
+    }
+
+    @Nullable
+    public PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+
+    public void setPrivateKey(@Nullable PrivateKey privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    public boolean isOnline() {
+        return online;
+    }
+
+    public void setOnline(boolean online) {
+        this.online = online;
+    }
+
+    @Nullable
+    public String getOnlineQrCodeUrl() {
+        return onlineQrCodeUrl;
+    }
+
+    public void setOnlineQrCodeUrl(@Nullable String onlineQrCodeUrl) {
+        this.onlineQrCodeUrl = onlineQrCodeUrl;
+    }
+
+    @Nullable
+    public String getCertificateQrCodeUrl() {
+        return certificateQrCodeUrl;
+    }
+
+    public void setCertificateQrCodeUrl(@Nullable String certificateQrCodeUrl) {
+        this.certificateQrCodeUrl = certificateQrCodeUrl;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o instanceof InvoiceQRCodeGeneratorRequest) {
+            InvoiceQRCodeGeneratorRequest other = (InvoiceQRCodeGeneratorRequest) o;
+            return other.canEqual(this)
+                    && online == other.online
+                    && Objects.equals(environmentUrl, other.environmentUrl)
+                    && Objects.equals(identifier, other.identifier)
+                    && Objects.equals(issueDate, other.issueDate)
+                    && Objects.equals(ctxType, other.ctxType)
+                    && Objects.equals(ctxValue, other.ctxValue)
+                    && Objects.equals(certSerial, other.certSerial)
+                    && Objects.equals(privateKey, other.privateKey)
+                    && Objects.equals(onlineQrCodeUrl, other.onlineQrCodeUrl)
+                    && Objects.equals(certificateQrCodeUrl, other.certificateQrCodeUrl);
+        }
+        return false;
+    }
+
+    protected boolean canEqual(Object other) {
+        return other instanceof InvoiceQRCodeGeneratorRequest;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(environmentUrl, identifier, issueDate, ctxType, ctxValue,
+                certSerial, privateKey, online, onlineQrCodeUrl, certificateQrCodeUrl);
+    }
+
+    @Override
+    public String toString() {
+        return "InvoiceQRCodeGeneratorRequest(environmentUrl=" + environmentUrl
+                + ", identifier=" + identifier
+                + ", issueDate=" + issueDate
+                + ", ctxType=" + ctxType
+                + ", ctxValue=" + ctxValue
+                + ", certSerial=" + certSerial
+                + ", privateKey=" + privateKey
+                + ", online=" + online
+                + ", onlineQrCodeUrl=" + onlineQrCodeUrl
+                + ", certificateQrCodeUrl=" + certificateQrCodeUrl + ")";
+    }
 }

--- a/src/main/java/io/alapierre/ksef/fop/Language.java
+++ b/src/main/java/io/alapierre/ksef/fop/Language.java
@@ -1,8 +1,5 @@
 package io.alapierre.ksef.fop;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 /**
  * Built-in language codes recognised by the library.
  *
@@ -12,8 +9,6 @@ import lombok.RequiredArgsConstructor;
  * as {@code "uk"} or {@code "ar-SA"}) — the resolution logic accepts arbitrary
  * tags and falls back to this default when no label file is available.</p>
  */
-@Getter
-@RequiredArgsConstructor
 public enum Language {
     PL("pl"),
     EN("en");
@@ -25,4 +20,12 @@ public enum Language {
     public static final String DEFAULT_LANGUAGE_TAG = "pl";
 
     private final String code;
+
+    Language(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
 }

--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -6,7 +6,6 @@ import io.alapierre.ksef.fop.internal.TemplateResolver;
 import io.alapierre.ksef.fop.internal.XmlFactories;
 import io.alapierre.ksef.fop.qr.QrCodeBuilder;
 import io.alapierre.ksef.fop.qr.QrCodeData;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fop.apps.*;
 import org.apache.fop.apps.io.InternalResourceResolver;
 import org.apache.fop.apps.io.ResourceResolverFactory;
@@ -15,6 +14,8 @@ import org.apache.fop.configuration.ConfigurationException;
 import org.apache.fop.configuration.DefaultConfigurationBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 
 import javax.xml.transform.*;
@@ -32,8 +33,9 @@ import java.util.Map;
  * @author Adrian Lapierre {@literal al@alapierre.io}
  * Copyrights by original author 2023.11.11
  */
-@Slf4j
 public class PdfGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger(PdfGenerator.class);
 
     private static final String MIME_PDF = "application/pdf";
 

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -47,7 +47,7 @@ public class UpoGenerationParams {
     /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
-    private List<Path> templateRoots;
+    private final List<Path> templateRoots;
 
     /**
      * @deprecated use the builder instead.

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -68,7 +68,7 @@ public class UpoGenerationParams {
         this.language = builder.language == null ? Language.PL : builder.language;
         this.languageLocale = builder.languageLocale;
         this.templatePath = builder.templatePath;
-        this.templateRoots = builder.templateRoots == null
+        this.templateRoots = builder.templateRoots.isEmpty()
                 ? Collections.emptyList()
                 : Collections.unmodifiableList(new ArrayList<>(builder.templateRoots));
     }
@@ -202,7 +202,7 @@ public class UpoGenerationParams {
         private Language language = Language.PL;
         private String languageLocale;
         private String templatePath;
-        private ArrayList<Path> templateRoots;
+        private final ArrayList<Path> templateRoots = new ArrayList<>();
 
         UpoGenerationParamsBuilder() {
         }
@@ -232,21 +232,19 @@ public class UpoGenerationParams {
         }
 
         public UpoGenerationParamsBuilder templateRoot(Path templateRoot) {
-            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
             this.templateRoots.add(templateRoot);
             return this;
         }
 
         public UpoGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
             if (templateRoots != null) {
-                if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
                 this.templateRoots.addAll(templateRoots);
             }
             return this;
         }
 
         public UpoGenerationParamsBuilder clearTemplateRoots() {
-            if (this.templateRoots != null) this.templateRoots.clear();
+            this.templateRoots.clear();
             return this;
         }
 

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -22,7 +22,7 @@ public class UpoGenerationParams {
      * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
      */
     @Deprecated
-    private Language language = Language.PL;
+    private Language language;
 
     /**
      * Optional BCP&nbsp;47 language tag used to select the label file for translations
@@ -45,14 +45,14 @@ public class UpoGenerationParams {
     /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
-    private List<Path> templateRoots = Collections.emptyList();
+    private List<Path> templateRoots;
 
     /**
      * @deprecated use the builder instead.
      */
     @Deprecated
     public UpoGenerationParams() {
-        this(UpoSchema.UPO_V4_3, null, null, null, null);
+        this(builder().schema(UpoSchema.UPO_V4_3));
     }
 
     /**
@@ -60,18 +60,17 @@ public class UpoGenerationParams {
      */
     @Deprecated
     public UpoGenerationParams(@NotNull UpoSchema schema, Language language) {
-        this(schema, language, null, null, null);
+        this(builder().schema(schema).language(language));
     }
 
-    private UpoGenerationParams(@NotNull UpoSchema schema, Language language, @Nullable String languageLocale,
-                               @Nullable String templatePath, List<Path> templateRoots) {
-        this.schema = Objects.requireNonNull(schema, "schema");
-        this.language = language == null ? Language.PL : language;
-        this.languageLocale = languageLocale;
-        this.templatePath = templatePath;
-        this.templateRoots = templateRoots == null
+    private UpoGenerationParams(UpoGenerationParamsBuilder builder) {
+        this.schema = Objects.requireNonNull(builder.schema, "schema");
+        this.language = builder.language == null ? Language.PL : builder.language;
+        this.languageLocale = builder.languageLocale;
+        this.templatePath = builder.templatePath;
+        this.templateRoots = builder.templateRoots == null
                 ? Collections.emptyList()
-                : Collections.unmodifiableList(new ArrayList<>(templateRoots));
+                : Collections.unmodifiableList(new ArrayList<>(builder.templateRoots));
     }
 
     @NotNull
@@ -253,7 +252,7 @@ public class UpoGenerationParams {
         }
 
         public UpoGenerationParams build() {
-            return new UpoGenerationParams(schema, language, languageLocale, templatePath, templateRoots);
+            return new UpoGenerationParams(this);
         }
 
         @Override

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -10,6 +10,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Parameters controlling how a KSeF UPO (Official Receipt Confirmation) is rendered to PDF.
+ */
 public class UpoGenerationParams {
 
     @NotNull
@@ -56,6 +59,8 @@ public class UpoGenerationParams {
     }
 
     /**
+     * @param schema the UPO schema to render
+     * @param language the label language
      * @deprecated use the builder instead.
      */
     @Deprecated
@@ -73,16 +78,25 @@ public class UpoGenerationParams {
                 : Collections.unmodifiableList(new ArrayList<>(builder.templateRoots));
     }
 
+    /**
+     * Returns the UPO schema to render.
+     * @return the UPO schema
+     */
     @NotNull
     public UpoSchema getSchema() {
         return schema;
     }
 
+    /**
+     * Sets the UPO schema to render.
+     * @param schema the UPO schema, never {@code null}
+     */
     public void setSchema(@NotNull UpoSchema schema) {
         this.schema = Objects.requireNonNull(schema, "schema");
     }
 
     /**
+     * @return the label language
      * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
      * language tag (e.g. {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}) and is not
      * limited to the values defined by this enum. Kept for backward compatibility.
@@ -94,6 +108,7 @@ public class UpoGenerationParams {
     }
 
     /**
+     * @param language the label language
      * @deprecated use {@link #languageLocale} instead.
      */
     @Deprecated
@@ -108,12 +123,18 @@ public class UpoGenerationParams {
      * default language ({@link Language#DEFAULT_LANGUAGE_TAG}) without raising an error.
      *
      * <p>When set, this value takes precedence over the deprecated {@link #language} enum.</p>
+     *
+     * @return the BCP&nbsp;47 language tag, or {@code null} if unset
      */
     @Nullable
     public String getLanguageLocale() {
         return languageLocale;
     }
 
+    /**
+     * Sets the BCP&nbsp;47 language tag used to select the label file.
+     * @param languageLocale the BCP&nbsp;47 language tag, or {@code null} to unset
+     */
     public void setLanguageLocale(@Nullable String languageLocale) {
         this.languageLocale = languageLocale;
     }
@@ -121,18 +142,24 @@ public class UpoGenerationParams {
     /**
      * Optional classpath-relative path to a custom XSLT UPO template.
      * When set, overrides the schema-derived default template path.
+     * @return the custom template path, or {@code null} to use the schema default
      */
     @Nullable
     public String getTemplatePath() {
         return templatePath;
     }
 
+    /**
+     * Sets the classpath-relative path to a custom XSLT UPO template.
+     * @param templatePath the custom template path, or {@code null} to use the schema default
+     */
     public void setTemplatePath(@Nullable String templatePath) {
         this.templatePath = templatePath;
     }
 
     /**
      * Returns an unmodifiable view of the configured filesystem template roots.
+     * @return the template roots, never {@code null}
      */
     public List<Path> getTemplateRoots() {
         return templateRoots;
@@ -148,6 +175,8 @@ public class UpoGenerationParams {
      *
      * <p>This is the single source of truth consumed by the rendering pipeline;
      * callers should not inspect {@link #languageLocale} or {@link #language} directly.</p>
+     *
+     * @return the resolved BCP&nbsp;47 language tag, never {@code null}
      */
     @NotNull
     public String resolveLanguageTag() {
@@ -174,6 +203,11 @@ public class UpoGenerationParams {
         return false;
     }
 
+    /**
+     * Tells whether {@code other} may be compared for equality with this instance.
+     * @param other the object to test
+     * @return {@code true} if {@code other} is a {@code UpoGenerationParams}
+     */
     protected boolean canEqual(Object other) {
         return other instanceof UpoGenerationParams;
     }
@@ -192,10 +226,17 @@ public class UpoGenerationParams {
                 + ", templateRoots=" + getTemplateRoots() + ")";
     }
 
+    /**
+     * Creates a new builder for {@link UpoGenerationParams}.
+     * @return a fresh builder
+     */
     public static UpoGenerationParamsBuilder builder() {
         return new UpoGenerationParamsBuilder();
     }
 
+    /**
+     * Fluent builder for {@link UpoGenerationParams}.
+     */
     public static final class UpoGenerationParamsBuilder {
 
         private UpoSchema schema;
@@ -207,12 +248,19 @@ public class UpoGenerationParams {
         UpoGenerationParamsBuilder() {
         }
 
+        /**
+         * Sets the UPO schema to render.
+         * @param schema the UPO schema
+         * @return this builder
+         */
         public UpoGenerationParamsBuilder schema(@NotNull UpoSchema schema) {
             this.schema = schema;
             return this;
         }
 
         /**
+         * @param language the label language
+         * @return this builder
          * @deprecated use {@link #languageLocale(String)} instead.
          */
         @Deprecated
@@ -221,21 +269,42 @@ public class UpoGenerationParams {
             return this;
         }
 
+        /**
+         * Sets the BCP&nbsp;47 language tag used to select the label file.
+         * @param languageLocale the BCP&nbsp;47 language tag, or {@code null} to unset
+         * @return this builder
+         */
         public UpoGenerationParamsBuilder languageLocale(@Nullable String languageLocale) {
             this.languageLocale = languageLocale;
             return this;
         }
 
+        /**
+         * Sets the classpath-relative path to a custom XSLT UPO template.
+         * @param templatePath the custom template path, or {@code null} to use the schema default
+         * @return this builder
+         */
         public UpoGenerationParamsBuilder templatePath(@Nullable String templatePath) {
             this.templatePath = templatePath;
             return this;
         }
 
+        /**
+         * Appends a single filesystem template root searched before the classpath.
+         * @param templateRoot the directory to append
+         * @return this builder
+         */
         public UpoGenerationParamsBuilder templateRoot(Path templateRoot) {
             this.templateRoots.add(templateRoot);
             return this;
         }
 
+        /**
+         * Appends a collection of filesystem template roots searched before the classpath.
+         * A {@code null} collection is ignored.
+         * @param templateRoots the directories to append, or {@code null}
+         * @return this builder
+         */
         public UpoGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
             if (templateRoots != null) {
                 this.templateRoots.addAll(templateRoots);
@@ -243,11 +312,19 @@ public class UpoGenerationParams {
             return this;
         }
 
+        /**
+         * Removes all template roots accumulated so far.
+         * @return this builder
+         */
         public UpoGenerationParamsBuilder clearTemplateRoots() {
             this.templateRoots.clear();
             return this;
         }
 
+        /**
+         * Builds an immutable {@link UpoGenerationParams} from this builder's state.
+         * @return the configured parameters
+         */
         public UpoGenerationParams build() {
             return new UpoGenerationParams(this);
         }

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -1,24 +1,15 @@
 package io.alapierre.ksef.fop;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.Singular;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpoGenerationParams {
 
     @NotNull
@@ -31,7 +22,6 @@ public class UpoGenerationParams {
      * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
      */
     @Deprecated
-    @Builder.Default
     private Language language = Language.PL;
 
     /**
@@ -55,29 +45,98 @@ public class UpoGenerationParams {
     /**
      * Ordered list of filesystem directories searched before the classpath when resolving templates.
      */
-    @Singular("templateRoot")
-    @Getter(AccessLevel.NONE)
-    @Setter(AccessLevel.NONE)
-    private List<Path> templateRoots;
+    private List<Path> templateRoots = Collections.emptyList();
+
+    /**
+     * @deprecated use the builder instead.
+     */
+    @Deprecated
+    public UpoGenerationParams() {
+        this(UpoSchema.UPO_V4_3, null, null, null, null);
+    }
 
     /**
      * @deprecated use the builder instead.
      */
     @Deprecated
     public UpoGenerationParams(@NotNull UpoSchema schema, Language language) {
-        this.schema = schema;
-        this.language = language != null ? language : Language.PL;
-        this.languageLocale = null;
-        this.templatePath = null;
-        this.templateRoots = Collections.emptyList();
+        this(schema, language, null, null, null);
+    }
+
+    private UpoGenerationParams(@NotNull UpoSchema schema, Language language, @Nullable String languageLocale,
+                               @Nullable String templatePath, List<Path> templateRoots) {
+        this.schema = Objects.requireNonNull(schema, "schema");
+        this.language = language == null ? Language.PL : language;
+        this.languageLocale = languageLocale;
+        this.templatePath = templatePath;
+        this.templateRoots = templateRoots == null
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(templateRoots));
+    }
+
+    @NotNull
+    public UpoSchema getSchema() {
+        return schema;
+    }
+
+    public void setSchema(@NotNull UpoSchema schema) {
+        this.schema = Objects.requireNonNull(schema, "schema");
+    }
+
+    /**
+     * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
+     * language tag (e.g. {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}) and is not
+     * limited to the values defined by this enum. Kept for backward compatibility.
+     * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
+     */
+    @Deprecated
+    public Language getLanguage() {
+        return language;
+    }
+
+    /**
+     * @deprecated use {@link #languageLocale} instead.
+     */
+    @Deprecated
+    public void setLanguage(Language language) {
+        this.language = language;
+    }
+
+    /**
+     * Optional BCP&nbsp;47 language tag used to select the label file for translations
+     * (e.g. {@code "en"}, {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}). Both
+     * {@code _} and {@code -} separators are accepted. Unknown tags fall back to the
+     * default language ({@link Language#DEFAULT_LANGUAGE_TAG}) without raising an error.
+     *
+     * <p>When set, this value takes precedence over the deprecated {@link #language} enum.</p>
+     */
+    @Nullable
+    public String getLanguageLocale() {
+        return languageLocale;
+    }
+
+    public void setLanguageLocale(@Nullable String languageLocale) {
+        this.languageLocale = languageLocale;
+    }
+
+    /**
+     * Optional classpath-relative path to a custom XSLT UPO template.
+     * When set, overrides the schema-derived default template path.
+     */
+    @Nullable
+    public String getTemplatePath() {
+        return templatePath;
+    }
+
+    public void setTemplatePath(@Nullable String templatePath) {
+        this.templatePath = templatePath;
     }
 
     /**
      * Returns an unmodifiable view of the configured filesystem template roots.
      */
     public List<Path> getTemplateRoots() {
-        if (templateRoots == null) return Collections.emptyList();
-        return Collections.unmodifiableList(templateRoots);
+        return templateRoots;
     }
 
     /**
@@ -99,5 +158,111 @@ public class UpoGenerationParams {
         }
         if (language != null) return language.getCode();
         return Language.DEFAULT_LANGUAGE_TAG;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o instanceof UpoGenerationParams) {
+            UpoGenerationParams other = (UpoGenerationParams) o;
+            return other.canEqual(this)
+                    && Objects.equals(schema, other.schema)
+                    && Objects.equals(language, other.language)
+                    && Objects.equals(languageLocale, other.languageLocale)
+                    && Objects.equals(templatePath, other.templatePath)
+                    && Objects.equals(getTemplateRoots(), other.getTemplateRoots());
+        }
+        return false;
+    }
+
+    protected boolean canEqual(Object other) {
+        return other instanceof UpoGenerationParams;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, language, languageLocale, templatePath, getTemplateRoots());
+    }
+
+    @Override
+    public String toString() {
+        return "UpoGenerationParams(schema=" + schema
+                + ", language=" + language
+                + ", languageLocale=" + languageLocale
+                + ", templatePath=" + templatePath
+                + ", templateRoots=" + getTemplateRoots() + ")";
+    }
+
+    public static UpoGenerationParamsBuilder builder() {
+        return new UpoGenerationParamsBuilder();
+    }
+
+    public static final class UpoGenerationParamsBuilder {
+
+        private UpoSchema schema;
+        private Language language = Language.PL;
+        private String languageLocale;
+        private String templatePath;
+        private ArrayList<Path> templateRoots;
+
+        UpoGenerationParamsBuilder() {
+        }
+
+        public UpoGenerationParamsBuilder schema(@NotNull UpoSchema schema) {
+            this.schema = Objects.requireNonNull(schema, "schema");
+            return this;
+        }
+
+        /**
+         * @deprecated use {@link #languageLocale(String)} instead.
+         */
+        @Deprecated
+        public UpoGenerationParamsBuilder language(Language language) {
+            this.language = language;
+            return this;
+        }
+
+        public UpoGenerationParamsBuilder languageLocale(@Nullable String languageLocale) {
+            this.languageLocale = languageLocale;
+            return this;
+        }
+
+        public UpoGenerationParamsBuilder templatePath(@Nullable String templatePath) {
+            this.templatePath = templatePath;
+            return this;
+        }
+
+        public UpoGenerationParamsBuilder templateRoot(Path templateRoot) {
+            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
+            this.templateRoots.add(templateRoot);
+            return this;
+        }
+
+        public UpoGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
+            if (templateRoots == null) {
+                throw new NullPointerException("templateRoots cannot be null");
+            }
+            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
+            this.templateRoots.addAll(templateRoots);
+            return this;
+        }
+
+        public UpoGenerationParamsBuilder clearTemplateRoots() {
+            if (this.templateRoots != null) this.templateRoots.clear();
+            return this;
+        }
+
+        public UpoGenerationParams build() {
+            return new UpoGenerationParams(schema, language, languageLocale, templatePath, templateRoots);
+        }
+
+        @Override
+        public String toString() {
+            return "UpoGenerationParams.UpoGenerationParamsBuilder(schema=" + schema
+                    + ", language=" + language
+                    + ", languageLocale=" + languageLocale
+                    + ", templatePath=" + templatePath
+                    + ", templateRoots=" + templateRoots + ")";
+        }
     }
 }

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -24,7 +24,6 @@ public class UpoGenerationParams {
      * limited to the values defined by this enum. Kept for backward compatibility.
      * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
      */
-    @Deprecated
     private Language language;
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -208,7 +208,7 @@ public class UpoGenerationParams {
         }
 
         public UpoGenerationParamsBuilder schema(@NotNull UpoSchema schema) {
-            this.schema = Objects.requireNonNull(schema, "schema");
+            this.schema = schema;
             return this;
         }
 
@@ -238,11 +238,10 @@ public class UpoGenerationParams {
         }
 
         public UpoGenerationParamsBuilder templateRoots(Collection<? extends Path> templateRoots) {
-            if (templateRoots == null) {
-                throw new NullPointerException("templateRoots cannot be null");
+            if (templateRoots != null) {
+                if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
+                this.templateRoots.addAll(templateRoots);
             }
-            if (this.templateRoots == null) this.templateRoots = new ArrayList<>();
-            this.templateRoots.addAll(templateRoots);
             return this;
         }
 

--- a/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
+++ b/src/main/java/io/alapierre/ksef/fop/UpoGenerationParams.java
@@ -18,35 +18,14 @@ public class UpoGenerationParams {
     @NotNull
     private UpoSchema schema;
 
-    /**
-     * @deprecated use {@link #languageLocale} instead, which accepts any BCP&nbsp;47
-     * language tag (e.g. {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}) and is not
-     * limited to the values defined by this enum. Kept for backward compatibility.
-     * When both are set, {@link #languageLocale} wins (see {@link #resolveLanguageTag()}).
-     */
     private Language language;
 
-    /**
-     * Optional BCP&nbsp;47 language tag used to select the label file for translations
-     * (e.g. {@code "en"}, {@code "en-US"}, {@code "uk"}, {@code "ar-SA"}). Both
-     * {@code _} and {@code -} separators are accepted. Unknown tags fall back to the
-     * default language ({@link Language#DEFAULT_LANGUAGE_TAG}) without raising an error.
-     *
-     * <p>When set, this value takes precedence over the deprecated {@link #language} enum.</p>
-     */
     @Nullable
     private String languageLocale;
 
-    /**
-     * Optional classpath-relative path to a custom XSLT UPO template.
-     * When set, overrides the schema-derived default template path.
-     */
     @Nullable
     private String templatePath;
 
-    /**
-     * Ordered list of filesystem directories searched before the classpath when resolving templates.
-     */
     private final List<Path> templateRoots;
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
+++ b/src/main/java/io/alapierre/ksef/fop/i18n/TranslationService.java
@@ -4,9 +4,10 @@ import io.alapierre.ksef.fop.Language;
 import io.alapierre.ksef.fop.internal.Strings;
 import io.alapierre.ksef.fop.internal.TemplateResolver;
 import io.alapierre.ksef.fop.internal.XmlFactories;
-import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -28,8 +29,9 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 
-@Slf4j
 public class TranslationService {
+
+    private static final Logger log = LoggerFactory.getLogger(TranslationService.class);
 
     private final Map<String, Document> DOCUMENT_CACHE = new ConcurrentHashMap<>();
 

--- a/src/main/java/io/alapierre/ksef/fop/qr/CryptoUtils.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/CryptoUtils.java
@@ -1,7 +1,6 @@
 package io.alapierre.ksef.fop.qr;
 
 import io.alapierre.ksef.fop.qr.exceptions.VerificationLinkGenerationException;
-import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
 import java.security.*;
@@ -11,7 +10,6 @@ import java.security.spec.MGF1ParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.util.Base64;
 
-@Slf4j
 public final class CryptoUtils {
 
     private static final String SHA_256 = "SHA-256";

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeBuilder.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeBuilder.java
@@ -3,7 +3,6 @@ package io.alapierre.ksef.fop.qr;
 import io.alapierre.ksef.fop.InvoiceQRCodeGeneratorRequest;
 import io.alapierre.ksef.fop.i18n.TranslationService;
 import io.alapierre.ksef.fop.qr.exceptions.QrCodeGenerationException;
-import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,11 +21,14 @@ import java.util.List;
  * - Direct URL (if provided in InvoiceQRCodeGeneratorRequest)
  * - Parameters (environmentUrl, identifier, issueDate, etc.) - URL will be generated
  */
-@RequiredArgsConstructor
 public class QrCodeBuilder {
 
     private static final int QR_SIZE = 200;
     private final TranslationService translationService;
+
+    public QrCodeBuilder(TranslationService translationService) {
+        this.translationService = translationService;
+    }
 
     /**
      * Builds QR codes based on the request. Returns null if request is null.

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
@@ -29,6 +29,8 @@ public class QrCodeData {
      */
     @Deprecated
     public QrCodeData() {
+        // Suppresses Sonar warning
+        this.qrCodeImage = new byte[0];
     }
 
     /**
@@ -171,7 +173,7 @@ public class QrCodeData {
      */
     public static final class QrCodeDataBuilder {
 
-        private byte @NotNull [] qrCodeImage;
+        private byte [] qrCodeImage;
         private String label;
         private String verificationLink;
         private String verificationLinkTitle;

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
@@ -31,6 +31,9 @@ public class QrCodeData {
     public QrCodeData() {
         // Suppresses Sonar warning
         this.qrCodeImage = new byte[0];
+        this.label = "";
+        this.verificationLink = "";
+        this.verificationLinkTitle = "";
     }
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
@@ -8,74 +8,111 @@ import java.util.Objects;
 /**
  * Represents a single QR code with its associated data for PDF generation.
  * Each QR code can have an image, a label displayed below it, and a verification link.
- * 
  */
 public class QrCodeData {
-    
-    /**
-     * The QR code image as byte array (PNG format)
-     */
+
     private byte @NotNull [] qrCodeImage;
-    
-    /**
-     * Label displayed below the QR code (e.g., KSeF number)
-     */
+
     @NotNull
     private String label;
-    
-    /**
-     * Verification link associated with this QR code
-     */
+
     @NotNull
     private String verificationLink;
 
-    /**
-     * Verification link associated with this QR code
-     */
     @NotNull
     private String verificationLinkTitle;
 
+    /**
+     * Creates an empty instance; populate it through the setters.
+     */
     public QrCodeData() {
     }
 
+    /**
+     * Creates a fully populated QR code.
+     * @param qrCodeImage the QR code image as a PNG byte array
+     * @param label the label displayed below the QR code
+     * @param verificationLink the verification link
+     * @param verificationLinkTitle the title of the verification link
+     */
     public QrCodeData(byte @NotNull [] qrCodeImage, @NotNull String label, @NotNull String verificationLink, @NotNull String verificationLinkTitle) {
-        this.qrCodeImage = qrCodeImage;
-        this.label = Objects.requireNonNull(label, "label");
-        this.verificationLink = Objects.requireNonNull(verificationLink, "verificationLink");
-        this.verificationLinkTitle = Objects.requireNonNull(verificationLinkTitle, "verificationLinkTitle");
+        this(builder()
+                .qrCodeImage(qrCodeImage)
+                .label(label)
+                .verificationLink(verificationLink)
+                .verificationLinkTitle(verificationLinkTitle));
     }
 
+    private QrCodeData(QrCodeDataBuilder builder) {
+        this.qrCodeImage = builder.qrCodeImage;
+        this.label = Objects.requireNonNull(builder.label, "label");
+        this.verificationLink = Objects.requireNonNull(builder.verificationLink, "verificationLink");
+        this.verificationLinkTitle = Objects.requireNonNull(builder.verificationLinkTitle, "verificationLinkTitle");
+    }
+
+    /**
+     * Returns the QR code image as a PNG byte array.
+     * @return the QR code image bytes
+     */
     public byte @NotNull [] getQrCodeImage() {
         return qrCodeImage;
     }
 
+    /**
+     * Sets the QR code image as a PNG byte array.
+     * @param qrCodeImage the QR code image bytes
+     */
     public void setQrCodeImage(byte @NotNull [] qrCodeImage) {
         this.qrCodeImage = qrCodeImage;
     }
 
+    /**
+     * Returns the label displayed below the QR code.
+     * @return the label
+     */
     @NotNull
     public String getLabel() {
         return label;
     }
 
+    /**
+     * Sets the label displayed below the QR code.
+     * @param label the label, never {@code null}
+     */
     public void setLabel(@NotNull String label) {
         this.label = Objects.requireNonNull(label, "label");
     }
 
+    /**
+     * Returns the verification link.
+     * @return the verification link
+     */
     @NotNull
     public String getVerificationLink() {
         return verificationLink;
     }
 
+    /**
+     * Sets the verification link.
+     * @param verificationLink the verification link, never {@code null}
+     */
     public void setVerificationLink(@NotNull String verificationLink) {
         this.verificationLink = Objects.requireNonNull(verificationLink, "verificationLink");
     }
 
+    /**
+     * Returns the title of the verification link.
+     * @return the verification link title
+     */
     @NotNull
     public String getVerificationLinkTitle() {
         return verificationLinkTitle;
     }
 
+    /**
+     * Sets the title of the verification link.
+     * @param verificationLinkTitle the verification link title, never {@code null}
+     */
     public void setVerificationLinkTitle(@NotNull String verificationLinkTitle) {
         this.verificationLinkTitle = Objects.requireNonNull(verificationLinkTitle, "verificationLinkTitle");
     }
@@ -94,6 +131,11 @@ public class QrCodeData {
         return false;
     }
 
+    /**
+     * Tells whether {@code other} may be compared for equality with this instance.
+     * @param other the object to test
+     * @return {@code true} if {@code other} is a {@code QrCodeData}
+     */
     protected boolean canEqual(Object other) {
         return other instanceof QrCodeData;
     }
@@ -113,10 +155,17 @@ public class QrCodeData {
                 + ", verificationLinkTitle=" + verificationLinkTitle + ")";
     }
 
+    /**
+     * Creates a new builder for {@link QrCodeData}.
+     * @return a fresh builder
+     */
     public static QrCodeDataBuilder builder() {
         return new QrCodeDataBuilder();
     }
 
+    /**
+     * Fluent builder for {@link QrCodeData}.
+     */
     public static final class QrCodeDataBuilder {
 
         private byte @NotNull [] qrCodeImage;
@@ -127,28 +176,52 @@ public class QrCodeData {
         QrCodeDataBuilder() {
         }
 
+        /**
+         * Sets the QR code image as a PNG byte array.
+         * @param qrCodeImage the QR code image bytes
+         * @return this builder
+         */
         public QrCodeDataBuilder qrCodeImage(byte @NotNull [] qrCodeImage) {
             this.qrCodeImage = qrCodeImage;
             return this;
         }
 
+        /**
+         * Sets the label displayed below the QR code.
+         * @param label the label
+         * @return this builder
+         */
         public QrCodeDataBuilder label(@NotNull String label) {
-            this.label = Objects.requireNonNull(label, "label");
+            this.label = label;
             return this;
         }
 
+        /**
+         * Sets the verification link.
+         * @param verificationLink the verification link
+         * @return this builder
+         */
         public QrCodeDataBuilder verificationLink(@NotNull String verificationLink) {
-            this.verificationLink = Objects.requireNonNull(verificationLink, "verificationLink");
+            this.verificationLink = verificationLink;
             return this;
         }
 
+        /**
+         * Sets the title of the verification link.
+         * @param verificationLinkTitle the verification link title
+         * @return this builder
+         */
         public QrCodeDataBuilder verificationLinkTitle(@NotNull String verificationLinkTitle) {
-            this.verificationLinkTitle = Objects.requireNonNull(verificationLinkTitle, "verificationLinkTitle");
+            this.verificationLinkTitle = verificationLinkTitle;
             return this;
         }
 
+        /**
+         * Builds a {@link QrCodeData} from this builder's state.
+         * @return the configured QR code data
+         */
         public QrCodeData build() {
-            return new QrCodeData(qrCodeImage, label, verificationLink, verificationLinkTitle);
+            return new QrCodeData(this);
         }
 
         @Override

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
@@ -24,7 +24,10 @@ public class QrCodeData {
 
     /**
      * Creates an empty instance; populate it through the setters.
+     *
+     * @deprecated use the builder instead.
      */
+    @Deprecated
     public QrCodeData() {
     }
 

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
@@ -1,17 +1,15 @@
 package io.alapierre.ksef.fop.qr;
 
-import lombok.*;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * Represents a single QR code with its associated data for PDF generation.
  * Each QR code can have an image, a label displayed below it, and a verification link.
  * 
  */
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class QrCodeData {
     
     /**
@@ -36,5 +34,129 @@ public class QrCodeData {
      */
     @NotNull
     private String verificationLinkTitle;
-    
+
+    public QrCodeData() {
+    }
+
+    public QrCodeData(byte @NotNull [] qrCodeImage, @NotNull String label, @NotNull String verificationLink, @NotNull String verificationLinkTitle) {
+        this.qrCodeImage = qrCodeImage;
+        this.label = Objects.requireNonNull(label, "label");
+        this.verificationLink = Objects.requireNonNull(verificationLink, "verificationLink");
+        this.verificationLinkTitle = Objects.requireNonNull(verificationLinkTitle, "verificationLinkTitle");
+    }
+
+    public byte @NotNull [] getQrCodeImage() {
+        return qrCodeImage;
+    }
+
+    public void setQrCodeImage(byte @NotNull [] qrCodeImage) {
+        this.qrCodeImage = qrCodeImage;
+    }
+
+    @NotNull
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(@NotNull String label) {
+        this.label = Objects.requireNonNull(label, "label");
+    }
+
+    @NotNull
+    public String getVerificationLink() {
+        return verificationLink;
+    }
+
+    public void setVerificationLink(@NotNull String verificationLink) {
+        this.verificationLink = Objects.requireNonNull(verificationLink, "verificationLink");
+    }
+
+    @NotNull
+    public String getVerificationLinkTitle() {
+        return verificationLinkTitle;
+    }
+
+    public void setVerificationLinkTitle(@NotNull String verificationLinkTitle) {
+        this.verificationLinkTitle = Objects.requireNonNull(verificationLinkTitle, "verificationLinkTitle");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o instanceof QrCodeData) {
+            QrCodeData other = (QrCodeData) o;
+            return other.canEqual(this)
+                    && Arrays.equals(qrCodeImage, other.qrCodeImage)
+                    && Objects.equals(label, other.label)
+                    && Objects.equals(verificationLink, other.verificationLink)
+                    && Objects.equals(verificationLinkTitle, other.verificationLinkTitle);
+        }
+        return false;
+    }
+
+    protected boolean canEqual(Object other) {
+        return other instanceof QrCodeData;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(qrCodeImage);
+        result = 31 * result + Objects.hash(label, verificationLink, verificationLinkTitle);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "QrCodeData(qrCodeImage=" + Arrays.toString(qrCodeImage)
+                + ", label=" + label
+                + ", verificationLink=" + verificationLink
+                + ", verificationLinkTitle=" + verificationLinkTitle + ")";
+    }
+
+    public static QrCodeDataBuilder builder() {
+        return new QrCodeDataBuilder();
+    }
+
+    public static final class QrCodeDataBuilder {
+
+        private byte @NotNull [] qrCodeImage;
+        private String label;
+        private String verificationLink;
+        private String verificationLinkTitle;
+
+        QrCodeDataBuilder() {
+        }
+
+        public QrCodeDataBuilder qrCodeImage(byte @NotNull [] qrCodeImage) {
+            this.qrCodeImage = qrCodeImage;
+            return this;
+        }
+
+        public QrCodeDataBuilder label(@NotNull String label) {
+            this.label = Objects.requireNonNull(label, "label");
+            return this;
+        }
+
+        public QrCodeDataBuilder verificationLink(@NotNull String verificationLink) {
+            this.verificationLink = Objects.requireNonNull(verificationLink, "verificationLink");
+            return this;
+        }
+
+        public QrCodeDataBuilder verificationLinkTitle(@NotNull String verificationLinkTitle) {
+            this.verificationLinkTitle = Objects.requireNonNull(verificationLinkTitle, "verificationLinkTitle");
+            return this;
+        }
+
+        public QrCodeData build() {
+            return new QrCodeData(qrCodeImage, label, verificationLink, verificationLinkTitle);
+        }
+
+        @Override
+        public String toString() {
+            return "QrCodeData.QrCodeDataBuilder(qrCodeImage=" + Arrays.toString(qrCodeImage)
+                    + ", label=" + label
+                    + ", verificationLink=" + verificationLink
+                    + ", verificationLinkTitle=" + verificationLinkTitle + ")";
+        }
+    }
 }

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeData.java
@@ -44,7 +44,7 @@ public class QrCodeData {
     }
 
     private QrCodeData(QrCodeDataBuilder builder) {
-        this.qrCodeImage = builder.qrCodeImage;
+        this.qrCodeImage = Objects.requireNonNull(builder.qrCodeImage, "qrCodeImage");
         this.label = Objects.requireNonNull(builder.label, "label");
         this.verificationLink = Objects.requireNonNull(builder.verificationLink, "verificationLink");
         this.verificationLinkTitle = Objects.requireNonNull(builder.verificationLinkTitle, "verificationLinkTitle");
@@ -63,7 +63,7 @@ public class QrCodeData {
      * @param qrCodeImage the QR code image bytes
      */
     public void setQrCodeImage(byte @NotNull [] qrCodeImage) {
-        this.qrCodeImage = qrCodeImage;
+        this.qrCodeImage = Objects.requireNonNull(qrCodeImage, "qrCodeImage");
     }
 
     /**

--- a/src/main/java/io/alapierre/ksef/fop/qr/QrCodeGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/QrCodeGenerator.java
@@ -6,17 +6,18 @@ import com.google.zxing.client.j2se.MatrixToImageWriter;
 import com.google.zxing.common.BitMatrix;
 import com.google.zxing.qrcode.QRCodeWriter;
 import io.alapierre.ksef.fop.qr.exceptions.BarcodeGenerationException;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import lombok.val;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Objects;
 
 
-@Slf4j
 public class QrCodeGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger(QrCodeGenerator.class);
 
     private QrCodeGenerator() {
     }
@@ -30,9 +31,10 @@ public class QrCodeGenerator {
      * @return The generated barcode as a byte array.
      * @throws BarcodeGenerationException if a problem with barcode generation occurs
      */
-    public static byte[] generateBarcode(@NonNull String barcodeText, int width, int height)  {
+    public static byte[] generateBarcode(String barcodeText, int width, int height)  {
+        Objects.requireNonNull(barcodeText, "barcodeText");
         try {
-            val buf = new ByteArrayOutputStream();
+            final ByteArrayOutputStream buf = new ByteArrayOutputStream();
             writeBarcode(barcodeText, width, height, buf);
             return buf.toByteArray();
         } catch (IOException ex) {
@@ -51,7 +53,9 @@ public class QrCodeGenerator {
      * @throws IOException if an I/O error occurs while writing the image to the output stream.
      * @throws BarcodeGenerationException if a problem with barcode generation occurs
      */
-    public static void writeBarcode(@NonNull String barcodeText, int width, int height, OutputStream out) throws IOException {
+    public static void writeBarcode(String barcodeText, int width, int height, OutputStream out) throws IOException {
+
+        Objects.requireNonNull(barcodeText, "barcodeText");
 
         if (width <= 0 || height <= 0) {
             throw new BarcodeGenerationException("width and height must be positive", null);

--- a/src/main/java/io/alapierre/ksef/fop/qr/VerificationLinkGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/qr/VerificationLinkGenerator.java
@@ -1,7 +1,6 @@
 package io.alapierre.ksef.fop.qr;
 
 import io.alapierre.ksef.fop.qr.enums.ContextIdentifierType;
-import lombok.extern.slf4j.Slf4j;
 
 import java.security.PrivateKey;
 import java.time.LocalDate;
@@ -9,7 +8,6 @@ import java.time.format.DateTimeFormatter;
 
 import static io.alapierre.ksef.fop.qr.CryptoUtils.computeUrlEncodedSignedHash;
 
-@Slf4j
 public final class VerificationLinkGenerator {
 
     private static final DateTimeFormatter KSEF_DATE = DateTimeFormatter.ofPattern("dd-MM-yyyy");

--- a/src/test/java/io/alapierre/ksef/fop/EqualsContractTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/EqualsContractTest.java
@@ -1,0 +1,37 @@
+package io.alapierre.ksef.fop;
+
+import io.alapierre.ksef.fop.qr.QrCodeData;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code equals}/{@code hashCode} contract of the value classes that carry hand-written
+ * implementations. Two warnings are suppressed because of how these classes are shaped, not to relax
+ * the relation itself: {@code NONFINAL_FIELDS} (they are mutable JavaBeans exposing setters) and
+ * {@code STRICT_INHERITANCE} (they are non-final and use the {@code canEqual} pattern instead of a
+ * final {@code equals}).
+ */
+class EqualsContractTest {
+
+    @Test
+    void invoiceGenerationParams() {
+        EqualsVerifier.forClass(InvoiceGenerationParams.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    void upoGenerationParams() {
+        EqualsVerifier.forClass(UpoGenerationParams.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+
+    @Test
+    void qrCodeData() {
+        EqualsVerifier.forClass(QrCodeData.class)
+                .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
+                .verify();
+    }
+}

--- a/src/test/java/io/alapierre/ksef/fop/GeneratePdfTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/GeneratePdfTest.java
@@ -1,6 +1,5 @@
 package io.alapierre.ksef.fop;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.fop.apps.FOUserAgent;
 import org.apache.fop.apps.Fop;
 import org.apache.fop.apps.FopFactory;
@@ -28,7 +27,6 @@ import java.security.Security;
  * @author Adrian Lapierre {@literal al@alapierre.io}
  * Copyrights by original author 2023.11.11
  */
-@Slf4j
 class GeneratePdfTest {
 
     static {

--- a/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,7 +38,7 @@ class GenerationParamsBuilderTest {
         void setsEveryProperty() {
             byte[] logo = {1, 2, 3};
             URI logoUri = URI.create("https://example.test/logo.png");
-            LocalDate currencyDate = LocalDate.of(2026, 6, 10);
+            LocalDate currencyDate = LocalDate.of(2026, Month.JUNE, 10);
             InvoiceQRCodeGeneratorRequest qr = InvoiceQRCodeGeneratorRequest.onlineQrBuilder("https://example.test/qr");
             Map<String, Object> customProperties = new HashMap<>();
             customProperties.put("foo", "bar");
@@ -78,7 +79,7 @@ class GenerationParamsBuilderTest {
         void settersSetEveryProperty() {
             byte[] logo = {4, 5, 6};
             URI logoUri = URI.create("https://example.test/logo2.png");
-            LocalDate currencyDate = LocalDate.of(2026, 1, 2);
+            LocalDate currencyDate = LocalDate.of(2026, Month.JANUARY, 2);
             InvoiceQRCodeGeneratorRequest qr = InvoiceQRCodeGeneratorRequest.onlineQrBuilder("https://example.test/qr2");
             Map<String, Object> customProperties = new HashMap<>();
             customProperties.put("baz", "qux");

--- a/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
@@ -34,6 +34,7 @@ class GenerationParamsBuilderTest {
     class InvoiceParams {
 
         @Test
+        @SuppressWarnings("deprecation")
         void setsEveryProperty() {
             byte[] logo = {1, 2, 3};
             URI logoUri = URI.create("https://example.test/logo.png");
@@ -134,6 +135,7 @@ class GenerationParamsBuilderTest {
     class UpoParams {
 
         @Test
+        @SuppressWarnings("deprecation")
         void setsEveryProperty() {
             UpoGenerationParams params = UpoGenerationParams.builder()
                     .schema(UpoSchema.UPO_V4_3)

--- a/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
@@ -1,0 +1,207 @@
+package io.alapierre.ksef.fop;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that each builder method on {@link InvoiceGenerationParams.InvoiceGenerationParamsBuilder}
+ * and {@link UpoGenerationParams.UpoGenerationParamsBuilder} sets the matching property on the built
+ * instance. These builders deliberately do not follow the JavaBean getter/setter naming, so the
+ * correspondence between builder methods and properties is not trivial.
+ */
+class GenerationParamsBuilderTest {
+
+    private static final Path ROOT_A = Paths.get("/templates/a");
+    private static final Path ROOT_B = Paths.get("/templates/b");
+
+    @Nested
+    class InvoiceParams {
+
+        @Test
+        void setsEveryProperty() {
+            byte[] logo = {1, 2, 3};
+            URI logoUri = URI.create("https://example.test/logo.png");
+            LocalDate currencyDate = LocalDate.of(2026, 6, 10);
+            InvoiceQRCodeGeneratorRequest qr = InvoiceQRCodeGeneratorRequest.onlineQrBuilder("https://example.test/qr");
+            Map<String, Object> customProperties = new HashMap<>();
+            customProperties.put("foo", "bar");
+
+            InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                    .verificationLink("https://example.test/verify")
+                    .logo(logo)
+                    .logoUri(logoUri)
+                    .currencyDate(currencyDate)
+                    .issuerUser("issuer")
+                    .showCorrectionDifferences(true)
+                    .schema(InvoiceSchema.FA3_1_0_E)
+                    .ksefNumber("KSEF-123")
+                    .invoiceQRCodeGeneratorRequest(qr)
+                    .templatePath("/custom/template.xsl")
+                    .customProperties(customProperties)
+                    .language(Language.EN)
+                    .languageLocale("en-US")
+                    .build();
+
+            assertEquals("https://example.test/verify", params.getVerificationLink());
+            assertArrayEquals(logo, params.getLogo());
+            assertEquals(logoUri, params.getLogoUri());
+            assertEquals(currencyDate, params.getCurrencyDate());
+            assertEquals("issuer", params.getIssuerUser());
+            assertTrue(params.isShowCorrectionDifferences());
+            assertEquals(InvoiceSchema.FA3_1_0_E, params.getSchema());
+            assertEquals("KSEF-123", params.getKsefNumber());
+            assertSame(qr, params.getInvoiceQRCodeGeneratorRequest());
+            assertEquals("/custom/template.xsl", params.getTemplatePath());
+            assertEquals(customProperties, params.getCustomProperties());
+            assertEquals(Language.EN, params.getLanguage());
+            assertEquals("en-US", params.getLanguageLocale());
+        }
+
+        @Test
+        void templateRootAppendsInOrder() {
+            InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                    .schema(InvoiceSchema.FA3_1_0_E)
+                    .templateRoot(ROOT_A)
+                    .templateRoot(ROOT_B)
+                    .build();
+
+            assertEquals(Arrays.asList(ROOT_A, ROOT_B), params.getTemplateRoots());
+        }
+
+        @Test
+        void templateRootsAddsWholeCollection() {
+            List<Path> roots = Arrays.asList(ROOT_A, ROOT_B);
+
+            InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                    .schema(InvoiceSchema.FA3_1_0_E)
+                    .templateRoots(roots)
+                    .build();
+
+            assertEquals(roots, params.getTemplateRoots());
+        }
+
+        @Test
+        void templateRootsToleratesNull() {
+            InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                    .schema(InvoiceSchema.FA3_1_0_E)
+                    .templateRoots(null)
+                    .build();
+
+            assertTrue(params.getTemplateRoots().isEmpty());
+        }
+
+        @Test
+        void clearTemplateRootsRemovesPreviouslyAddedRoots() {
+            InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                    .schema(InvoiceSchema.FA3_1_0_E)
+                    .templateRoot(ROOT_A)
+                    .clearTemplateRoots()
+                    .templateRoot(ROOT_B)
+                    .build();
+
+            assertEquals(Collections.singletonList(ROOT_B), params.getTemplateRoots());
+        }
+
+        @Test
+        void templateRootsViewIsUnmodifiable() {
+            InvoiceGenerationParams params = InvoiceGenerationParams.builder()
+                    .schema(InvoiceSchema.FA3_1_0_E)
+                    .templateRoot(ROOT_A)
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class,
+                    () -> params.getTemplateRoots().add(ROOT_B));
+        }
+    }
+
+    @Nested
+    class UpoParams {
+
+        @Test
+        void setsEveryProperty() {
+            UpoGenerationParams params = UpoGenerationParams.builder()
+                    .schema(UpoSchema.UPO_V4_3)
+                    .language(Language.EN)
+                    .languageLocale("en-US")
+                    .templatePath("/custom/upo.xsl")
+                    .build();
+
+            assertEquals(UpoSchema.UPO_V4_3, params.getSchema());
+            assertEquals(Language.EN, params.getLanguage());
+            assertEquals("en-US", params.getLanguageLocale());
+            assertEquals("/custom/upo.xsl", params.getTemplatePath());
+        }
+
+        @Test
+        void templateRootAppendsInOrder() {
+            UpoGenerationParams params = UpoGenerationParams.builder()
+                    .schema(UpoSchema.UPO_V4_3)
+                    .templateRoot(ROOT_A)
+                    .templateRoot(ROOT_B)
+                    .build();
+
+            assertEquals(Arrays.asList(ROOT_A, ROOT_B), params.getTemplateRoots());
+        }
+
+        @Test
+        void templateRootsAddsWholeCollection() {
+            List<Path> roots = Arrays.asList(ROOT_A, ROOT_B);
+
+            UpoGenerationParams params = UpoGenerationParams.builder()
+                    .schema(UpoSchema.UPO_V4_3)
+                    .templateRoots(roots)
+                    .build();
+
+            assertEquals(roots, params.getTemplateRoots());
+        }
+
+        @Test
+        void templateRootsToleratesNull() {
+            UpoGenerationParams params = UpoGenerationParams.builder()
+                    .schema(UpoSchema.UPO_V4_3)
+                    .templateRoots(null)
+                    .build();
+
+            assertTrue(params.getTemplateRoots().isEmpty());
+        }
+
+        @Test
+        void clearTemplateRootsRemovesPreviouslyAddedRoots() {
+            UpoGenerationParams params = UpoGenerationParams.builder()
+                    .schema(UpoSchema.UPO_V4_3)
+                    .templateRoot(ROOT_A)
+                    .clearTemplateRoots()
+                    .templateRoot(ROOT_B)
+                    .build();
+
+            assertEquals(Collections.singletonList(ROOT_B), params.getTemplateRoots());
+        }
+
+        @Test
+        void templateRootsViewIsUnmodifiable() {
+            UpoGenerationParams params = UpoGenerationParams.builder()
+                    .schema(UpoSchema.UPO_V4_3)
+                    .templateRoot(ROOT_A)
+                    .build();
+
+            assertThrows(UnsupportedOperationException.class,
+                    () -> params.getTemplateRoots().add(ROOT_B));
+        }
+    }
+}

--- a/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
@@ -126,8 +126,8 @@ class GenerationParamsBuilderTest {
                     .templateRoot(ROOT_A)
                     .build();
 
-            assertThrows(UnsupportedOperationException.class,
-                    () -> params.getTemplateRoots().add(ROOT_B));
+            List<Path> roots = params.getTemplateRoots();
+            assertThrows(UnsupportedOperationException.class, () -> roots.add(ROOT_B));
         }
     }
 
@@ -202,8 +202,8 @@ class GenerationParamsBuilderTest {
                     .templateRoot(ROOT_A)
                     .build();
 
-            assertThrows(UnsupportedOperationException.class,
-                    () -> params.getTemplateRoots().add(ROOT_B));
+            List<Path> roots = params.getTemplateRoots();
+            assertThrows(UnsupportedOperationException.class, () -> roots.add(ROOT_B));
         }
     }
 }

--- a/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/GenerationParamsBuilderTest.java
@@ -20,10 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies that each builder method on {@link InvoiceGenerationParams.InvoiceGenerationParamsBuilder}
- * and {@link UpoGenerationParams.UpoGenerationParamsBuilder} sets the matching property on the built
- * instance. These builders deliberately do not follow the JavaBean getter/setter naming, so the
- * correspondence between builder methods and properties is not trivial.
+ * Verifies that both construction paths populate {@link InvoiceGenerationParams} and
+ * {@link UpoGenerationParams}: the fluent builder (which deliberately does not follow JavaBean
+ * getter/setter naming) and the plain setters on a no-arg instance.
  */
 class GenerationParamsBuilderTest {
 
@@ -72,6 +71,46 @@ class GenerationParamsBuilderTest {
             assertEquals(customProperties, params.getCustomProperties());
             assertEquals(Language.EN, params.getLanguage());
             assertEquals("en-US", params.getLanguageLocale());
+        }
+
+        @Test
+        @SuppressWarnings("deprecation")
+        void settersSetEveryProperty() {
+            byte[] logo = {4, 5, 6};
+            URI logoUri = URI.create("https://example.test/logo2.png");
+            LocalDate currencyDate = LocalDate.of(2026, 1, 2);
+            InvoiceQRCodeGeneratorRequest qr = InvoiceQRCodeGeneratorRequest.onlineQrBuilder("https://example.test/qr2");
+            Map<String, Object> customProperties = new HashMap<>();
+            customProperties.put("baz", "qux");
+
+            InvoiceGenerationParams params = new InvoiceGenerationParams();
+            params.setVerificationLink("https://example.test/verify2");
+            params.setLogo(logo);
+            params.setLogoUri(logoUri);
+            params.setCurrencyDate(currencyDate);
+            params.setIssuerUser("issuer2");
+            params.setShowCorrectionDifferences(true);
+            params.setSchema(InvoiceSchema.FA3_1_0_E);
+            params.setKsefNumber("KSEF-999");
+            params.setInvoiceQRCodeGeneratorRequest(qr);
+            params.setTemplatePath("/custom/template2.xsl");
+            params.setCustomProperties(customProperties);
+            params.setLanguage(Language.EN);
+            params.setLanguageLocale("uk");
+
+            assertEquals("https://example.test/verify2", params.getVerificationLink());
+            assertArrayEquals(logo, params.getLogo());
+            assertEquals(logoUri, params.getLogoUri());
+            assertEquals(currencyDate, params.getCurrencyDate());
+            assertEquals("issuer2", params.getIssuerUser());
+            assertTrue(params.isShowCorrectionDifferences());
+            assertEquals(InvoiceSchema.FA3_1_0_E, params.getSchema());
+            assertEquals("KSEF-999", params.getKsefNumber());
+            assertSame(qr, params.getInvoiceQRCodeGeneratorRequest());
+            assertEquals("/custom/template2.xsl", params.getTemplatePath());
+            assertEquals(customProperties, params.getCustomProperties());
+            assertEquals(Language.EN, params.getLanguage());
+            assertEquals("uk", params.getLanguageLocale());
         }
 
         @Test
@@ -148,6 +187,21 @@ class GenerationParamsBuilderTest {
             assertEquals(Language.EN, params.getLanguage());
             assertEquals("en-US", params.getLanguageLocale());
             assertEquals("/custom/upo.xsl", params.getTemplatePath());
+        }
+
+        @Test
+        @SuppressWarnings("deprecation")
+        void settersSetEveryProperty() {
+            UpoGenerationParams params = new UpoGenerationParams();
+            params.setSchema(UpoSchema.UPO_V4_3);
+            params.setLanguage(Language.EN);
+            params.setLanguageLocale("uk");
+            params.setTemplatePath("/custom/upo2.xsl");
+
+            assertEquals(UpoSchema.UPO_V4_3, params.getSchema());
+            assertEquals(Language.EN, params.getLanguage());
+            assertEquals("uk", params.getLanguageLocale());
+            assertEquals("/custom/upo2.xsl", params.getTemplatePath());
         }
 
         @Test

--- a/src/test/java/io/alapierre/ksef/fop/MultilangPdfGenerationTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/MultilangPdfGenerationTest.java
@@ -1,6 +1,5 @@
 package io.alapierre.ksef.fop;
 
-import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.Security;
 
-@Slf4j
 class MultilangPdfGenerationTest {
 
     static {

--- a/src/test/java/io/alapierre/ksef/fop/qr/QrCodeDataBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/qr/QrCodeDataBuilderTest.java
@@ -8,9 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * Verifies that each {@link QrCodeData.QrCodeDataBuilder} method sets the matching property on the
- * built instance, and that the not-null validation is enforced by {@link QrCodeData#build()} rather
- * than by the individual builder setters.
+ * Verifies that {@link QrCodeData} is populated correctly through both paths: the fluent builder
+ * (whose not-null validation is deferred to {@link QrCodeData#build()}) and the plain setters
+ * (which validate eagerly).
  */
 class QrCodeDataBuilderTest {
 
@@ -79,5 +79,37 @@ class QrCodeDataBuilderTest {
     void builderSettersDoNotValidateEagerly() {
         // Validation lives in the private constructor, so the setter accepts a null without throwing.
         assertDoesNotThrow(() -> QrCodeData.builder().label(null));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void settersSetEveryProperty() {
+        byte[] image = {4, 5, 6};
+
+        QrCodeData data = new QrCodeData();
+        data.setQrCodeImage(image);
+        data.setLabel("KSeF 999");
+        data.setVerificationLink("https://example.test/verify2");
+        data.setVerificationLinkTitle("Verify2");
+
+        assertArrayEquals(image, data.getQrCodeImage());
+        assertEquals("KSeF 999", data.getLabel());
+        assertEquals("https://example.test/verify2", data.getVerificationLink());
+        assertEquals("Verify2", data.getVerificationLinkTitle());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void settersRejectNull() {
+        QrCodeData data = new QrCodeData();
+
+        assertEquals("qrCodeImage",
+                assertThrows(NullPointerException.class, () -> data.setQrCodeImage(null)).getMessage());
+        assertEquals("label",
+                assertThrows(NullPointerException.class, () -> data.setLabel(null)).getMessage());
+        assertEquals("verificationLink",
+                assertThrows(NullPointerException.class, () -> data.setVerificationLink(null)).getMessage());
+        assertEquals("verificationLinkTitle",
+                assertThrows(NullPointerException.class, () -> data.setVerificationLinkTitle(null)).getMessage());
     }
 }

--- a/src/test/java/io/alapierre/ksef/fop/qr/QrCodeDataBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/qr/QrCodeDataBuilderTest.java
@@ -32,6 +32,17 @@ class QrCodeDataBuilderTest {
     }
 
     @Test
+    void buildRejectsNullQrCodeImage() {
+        QrCodeData.QrCodeDataBuilder builder = QrCodeData.builder()
+                .label("label")
+                .verificationLink("link")
+                .verificationLinkTitle("title");
+
+        NullPointerException ex = assertThrows(NullPointerException.class, builder::build);
+        assertEquals("qrCodeImage", ex.getMessage());
+    }
+
+    @Test
     void buildRejectsNullLabel() {
         QrCodeData.QrCodeDataBuilder builder = QrCodeData.builder()
                 .qrCodeImage(new byte[0])

--- a/src/test/java/io/alapierre/ksef/fop/qr/QrCodeDataBuilderTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/qr/QrCodeDataBuilderTest.java
@@ -1,0 +1,72 @@
+package io.alapierre.ksef.fop.qr;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Verifies that each {@link QrCodeData.QrCodeDataBuilder} method sets the matching property on the
+ * built instance, and that the not-null validation is enforced by {@link QrCodeData#build()} rather
+ * than by the individual builder setters.
+ */
+class QrCodeDataBuilderTest {
+
+    @Test
+    void setsEveryProperty() {
+        byte[] image = {1, 2, 3};
+
+        QrCodeData data = QrCodeData.builder()
+                .qrCodeImage(image)
+                .label("KSeF 123")
+                .verificationLink("https://example.test/verify")
+                .verificationLinkTitle("Verify")
+                .build();
+
+        assertArrayEquals(image, data.getQrCodeImage());
+        assertEquals("KSeF 123", data.getLabel());
+        assertEquals("https://example.test/verify", data.getVerificationLink());
+        assertEquals("Verify", data.getVerificationLinkTitle());
+    }
+
+    @Test
+    void buildRejectsNullLabel() {
+        QrCodeData.QrCodeDataBuilder builder = QrCodeData.builder()
+                .qrCodeImage(new byte[0])
+                .verificationLink("link")
+                .verificationLinkTitle("title");
+
+        NullPointerException ex = assertThrows(NullPointerException.class, builder::build);
+        assertEquals("label", ex.getMessage());
+    }
+
+    @Test
+    void buildRejectsNullVerificationLink() {
+        QrCodeData.QrCodeDataBuilder builder = QrCodeData.builder()
+                .qrCodeImage(new byte[0])
+                .label("label")
+                .verificationLinkTitle("title");
+
+        NullPointerException ex = assertThrows(NullPointerException.class, builder::build);
+        assertEquals("verificationLink", ex.getMessage());
+    }
+
+    @Test
+    void buildRejectsNullVerificationLinkTitle() {
+        QrCodeData.QrCodeDataBuilder builder = QrCodeData.builder()
+                .qrCodeImage(new byte[0])
+                .label("label")
+                .verificationLink("link");
+
+        NullPointerException ex = assertThrows(NullPointerException.class, builder::build);
+        assertEquals("verificationLinkTitle", ex.getMessage());
+    }
+
+    @Test
+    void builderSettersDoNotValidateEagerly() {
+        // Validation lives in the private constructor, so the setter accepts a null without throwing.
+        assertDoesNotThrow(() -> QrCodeData.builder().label(null));
+    }
+}

--- a/src/test/java/io/alapierre/ksef/fop/qr/helpers/CertificateBuilders.java
+++ b/src/test/java/io/alapierre/ksef/fop/qr/helpers/CertificateBuilders.java
@@ -1,7 +1,5 @@
 package io.alapierre.ksef.fop.qr.helpers;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.X500NameBuilder;
 import org.bouncycastle.asn1.x500.style.BCStyle;
@@ -79,10 +77,16 @@ public class CertificateBuilders {
         return build();
     }
 
-    @RequiredArgsConstructor
-    @Getter
     public class X500NameHolder {
 
         private final X500Name x500Name;
+
+        public X500NameHolder(X500Name x500Name) {
+            this.x500Name = x500Name;
+        }
+
+        public X500Name getX500Name() {
+            return x500Name;
+        }
     }
 }

--- a/src/test/java/io/alapierre/ksef/fop/qr/helpers/SelfSignedCertificate.java
+++ b/src/test/java/io/alapierre/ksef/fop/qr/helpers/SelfSignedCertificate.java
@@ -1,18 +1,26 @@
 package io.alapierre.ksef.fop.qr.helpers;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 
-@RequiredArgsConstructor
-@Getter
 public class SelfSignedCertificate {
 
     private final X509Certificate certificate;
     private final KeyPair keyPair;
+
+    public SelfSignedCertificate(X509Certificate certificate, KeyPair keyPair) {
+        this.certificate = certificate;
+        this.keyPair = keyPair;
+    }
+
+    public X509Certificate getCertificate() {
+        return certificate;
+    }
+
+    public KeyPair getKeyPair() {
+        return keyPair;
+    }
 
     public PrivateKey getPrivateKey() {
         return keyPair.getPrivate();


### PR DESCRIPTION
## Why remove Lombok

Lombok generates our public API (getters, setters, builders, `equals`/`hashCode`, constructors) at compile time. That generated surface depends on Lombok's internal behaviour, so a Lombok upgrade can silently change the published API and break binary
backward compatibility for downstream consumers, with no visible change in our own source. For a library published to Maven Central that is a risk we would rather not carry, so we replace Lombok with explicit code whose API only changes when we change it.

## What

1. **Add a `japicmp` backward-compatibility gate** (bound to `verify`): every build is compared against the previously released version and fails on binary- or source-incompatible changes. The baseline is auto-resolved, so nothing needs bumping at release time.
2. **Replace all Lombok usage with explicit, hand-written Java** and drop the dependency. The gate confirms the public API is unchanged against `1.2.24`.

### Notes
- Builders are now `final` (their only constructor is package-private, so no external consumer could ever subclass them). japicmp reports this as the non-breaking `CLASS_NOW_NOT_EXTENDABLE` (see siom79/japicmp#426) and it is accepted in the POM.
- `@NotNull` parameters use `Objects.requireNonNull`, the `@Singular` builders build their immutable list in the object constructor, and unused `@Slf4j` loggers were removed.

🤖 Assisted by [Claude Code](https://claude.com/claude-code)
