### PR TITLE
feat: expose API to clear compiled XSLT template cache

### DIFF
--- a/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
+++ b/src/main/java/io/alapierre/ksef/fop/PdfGenerator.java
@@ -366,4 +366,12 @@ public class PdfGenerator {
         }
     }
 
+    /**
+     * Clears the in-memory cache of compiled XSLT templates used by PDF generation.
+     * Safe to call from any thread; the next render recompiles from the current template source.
+     */
+    public static void clearCompiledTemplateCache() {
+        XmlFactories.clearCompiledTemplateCache();
+    }
+
 }

--- a/src/main/java/io/alapierre/ksef/fop/internal/XmlFactories.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/XmlFactories.java
@@ -145,6 +145,14 @@ public final class XmlFactories {
         }
     }
 
+    /**
+     * Clears the in-memory cache of compiled XSLT {@link Templates}.
+     * Call after template or include files change at runtime (e.g. management API upload).
+     */
+    public static void clearCompiledTemplateCache() {
+        TEMPLATE_CACHE.clear();
+    }
+
     private XmlFactories() {
         // utility class
     }

--- a/src/test/java/io/alapierre/ksef/fop/internal/XmlFactoriesTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/XmlFactoriesTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamResult;
@@ -15,6 +16,7 @@ import java.io.ByteArrayInputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class XmlFactoriesTest {
@@ -129,5 +131,21 @@ class XmlFactoriesTest {
     private static Transformer createStylesheetTransformer() throws TransformerException {
         StreamSource stylesheet = new StreamSource(new ByteArrayInputStream(TRIVIAL_STYLESHEET.getBytes(StandardCharsets.UTF_8)));
         return XmlFactories.createTransformerFactory().newTransformer(stylesheet);
+    }
+
+    @Test
+    void clearCompiledTemplateCache_allowsRecompilation() throws Exception {
+        TemplateResolver resolver = new TemplateResolver();
+        String templatePath = "templates/fa3/ksef_invoice.xsl";
+
+        Templates first = XmlFactories.getTemplate(resolver, templatePath);
+        Templates second = XmlFactories.getTemplate(resolver, templatePath);
+        assertNotNull(first);
+        assertNotNull(second);
+
+        XmlFactories.clearCompiledTemplateCache();
+
+        Templates afterClear = XmlFactories.getTemplate(resolver, templatePath);
+        assertNotNull(afterClear);
     }
 }


### PR DESCRIPTION
## Summary

- Add `XmlFactories.clearCompiledTemplateCache()` to drop the in-memory map of compiled Saxon `Templates`.
- Expose `PdfGenerator.clearCompiledTemplateCache()` as the public entry point for host applications.
- Add a regression test verifying recompilation after cache clear.

## Problem

`ksef-fop` compiles XSLT (including `xsl:include` / `xsl:import` fragments such as `invoice-rows.xsl`) once and keeps the result in a JVM-wide cache keyed by resource roots and template path. That is correct for static deployments, but breaks dynamic template management:

- The serve URL stays the same, e.g. `…/template-api/xslt/ksef_invoice.xsl`
- After a update the URL returns fresh content
- PDF generation still uses the previously compiled `Templates` until the process restarts

Integrators that mutate templates at runtime while preserving stable paths need an explicit invalidation hook instead of disabling the cache globally or restarting the service.
