### PR TITLE
feat: add pluggable RemoteResourceFetcher for remote HTTP template fe…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ RemoteResourceFetcher stub = uri -> "<xsl:stylesheet version=\"1.0\"/>".getBytes
 |------|-------------------------------|----------------------------------------|
 | **SSRF** | Only URLs already accepted by `UrlResourceRoot` containment are passed to `fetch` | Do not widen scope (e.g. follow redirects to external hosts, honour `X-Forwarded-*` overrides, or fetch URLs outside the passed `URI`) |
 | **Unbounded downloads** | 16 MB response cap | Enforce a comparable body size limit |
-| **Redirect abuse** | Redirects disabled | Do not follow redirects unless you re-validate the target URL against the resource root |
+| **Redirect abuse** | Redirects disabled | Do not follow redirects; ksef-fop validates only the original URL before calling `fetch` |
 | **Credential leakage** | No auth headers sent | If you propagate `Authorization` or cookies, restrict to trusted template-server URLs only |
 | **Untrusted content** | N/A (transport) | Fetch only from operator-controlled template servers; treat response bytes as trusted input to XSLT only when the source is trusted |
 | **TLS** | JVM default trust store | Use HTTPS and appropriate certificate validation for production template servers |

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@
 * [Invoice PDF](#invoices)
 * [Examples](#examples)
 * [Custom templates](#custom-templates)
+* [Remote HTTP template fetching](#remote-http-template-fetching)
 * [Custom translations](#custom-translations)
 * [Custom properties](#custom-properties)
 * [FOP Schema](#fop-schema)
@@ -147,6 +148,58 @@ template is resolved automatically from the schema.
 
 > **Security note:** `templatePath` is resolved through `TemplateResolver` (classpath / template roots /
 > catalog-mapped HTTPS). Make sure untrusted users cannot control this value or inject catalog entries.
+
+## Remote HTTP template fetching
+
+When `InvoiceGenerationParams.resourceRoots` (or `UpoGenerationParams.resourceRoots`) includes an
+`http:` or `https:` base URL, ksef-fop fetches stylesheets, includes, logos and label files over
+HTTP from that base. The actual HTTP client is pluggable via **`RemoteResourceFetcher`**
+(a `@FunctionalInterface` with a single `fetch(URI)` method).
+
+### Default behaviour
+
+If the host application does **nothing**, ksef-fop uses **`HttpURLConnectionRemoteResourceFetcher`**:
+GET only, no redirect following, 10 s timeouts, 16 MB body cap. URL containment (staying within the
+configured resource root, rejecting `../` escapes) is enforced by `UrlResourceRoot` **before** the
+fetcher is called.
+
+### Registering a custom client
+
+Host applications that embed ksef-fop (e.g. a Micronaut service with its own `HttpClient`) register
+an implementation at startup:
+
+````java
+RemoteResourceFetchers.setGlobal(myFetcher);
+````
+
+`TemplateResolver` obtains the active fetcher via `RemoteResourceFetchers.get()` — you do **not**
+pass it through `InvoiceGenerationParams`.
+
+For tests and stubs, a lambda is enough:
+
+````java
+RemoteResourceFetcher stub = uri -> "<xsl:stylesheet version=\"1.0\"/>".getBytes(StandardCharsets.UTF_8);
+````
+
+### Host application responsibility
+
+> [!IMPORTANT]
+> **Providing a correct `RemoteResourceFetcher` implementation (or consciously using the built-in
+> default) is the responsibility of the application that embeds ksef-fop.** The library validates
+> that fetched URLs stay under configured HTTP resource roots, but it cannot audit your HTTP
+> stack. An incorrect or careless custom fetcher can introduce serious vulnerabilities.
+
+| Risk | What the built-in default does | What your implementation must guarantee |
+|------|-------------------------------|----------------------------------------|
+| **SSRF** | Only URLs already accepted by `UrlResourceRoot` containment are passed to `fetch` | Do not widen scope (e.g. follow redirects to external hosts, honour `X-Forwarded-*` overrides, or fetch URLs outside the passed `URI`) |
+| **Unbounded downloads** | 16 MB response cap | Enforce a comparable body size limit |
+| **Redirect abuse** | Redirects disabled | Do not follow redirects unless you re-validate the target URL against the resource root |
+| **Credential leakage** | No auth headers sent | If you propagate `Authorization` or cookies, restrict to trusted template-server URLs only |
+| **Untrusted content** | N/A (transport) | Fetch only from operator-controlled template servers; treat response bytes as trusted input to XSLT only when the source is trusted |
+| **TLS** | JVM default trust store | Use HTTPS and appropriate certificate validation for production template servers |
+
+If you do not need a custom HTTP stack, **prefer the default** — do not register a fetcher unless
+you have a concrete integration requirement (framework `HttpClient`, observability, auth propagation).
 
 ## Custom translations
 

--- a/src/main/java/io/alapierre/ksef/fop/http/HttpURLConnectionRemoteResourceFetcher.java
+++ b/src/main/java/io/alapierre/ksef/fop/http/HttpURLConnectionRemoteResourceFetcher.java
@@ -1,0 +1,83 @@
+package io.alapierre.ksef.fop.http;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+
+/**
+ * Default {@link RemoteResourceFetcher} using JDK {@link HttpURLConnection}.
+ */
+public final class HttpURLConnectionRemoteResourceFetcher implements RemoteResourceFetcher {
+
+    public static final HttpURLConnectionRemoteResourceFetcher INSTANCE =
+            new HttpURLConnectionRemoteResourceFetcher();
+
+    public static final int REMOTE_TIMEOUT_MS = 10_000;
+    public static final int MAX_REMOTE_BYTES = 16 * 1024 * 1024;
+
+    private static final String ACCEPT_HEADER =
+            "application/xslt+xml, text/xml, application/xml, */*";
+
+    private HttpURLConnectionRemoteResourceFetcher() {
+    }
+
+    @Override
+    public byte @NotNull [] fetch(@NotNull URI url) throws RemoteResourceFetchException {
+        String urlString = url.toString();
+        String scheme = url.getScheme();
+        if (scheme == null
+                || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
+            throw new RemoteResourceFetchException(
+                    url,
+                    "Only http and https URLs are supported: " + urlString,
+                    null);
+        }
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) new URL(urlString).openConnection();
+            connection.setConnectTimeout(REMOTE_TIMEOUT_MS);
+            connection.setReadTimeout(REMOTE_TIMEOUT_MS);
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestProperty("Accept", ACCEPT_HEADER);
+            connection.setRequestMethod("GET");
+
+            int status = connection.getResponseCode();
+            if (status != HttpURLConnection.HTTP_OK) {
+                throw new RemoteResourceFetchException(url, status);
+            }
+
+            return readFully(connection.getInputStream());
+        } catch (RemoteResourceFetchException e) {
+            throw e;
+        } catch (IOException e) {
+            throw new RemoteResourceFetchException(
+                    url,
+                    "Failed to fetch remote resource (server may be down): " + urlString
+                            + " — " + e.getMessage(),
+                    e);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private static byte[] readFully(InputStream in) throws IOException, RemoteResourceFetchException {
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        byte[] chunk = new byte[8192];
+        int n;
+        while ((n = in.read(chunk)) != -1) {
+            buf.write(chunk, 0, n);
+            if (buf.size() > MAX_REMOTE_BYTES) {
+                throw new IOException("Remote resource exceeds maximum allowed size of "
+                        + MAX_REMOTE_BYTES + " bytes");
+            }
+        }
+        return buf.toByteArray();
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/http/RemoteResourceFetchException.java
+++ b/src/main/java/io/alapierre/ksef/fop/http/RemoteResourceFetchException.java
@@ -1,0 +1,39 @@
+package io.alapierre.ksef.fop.http;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+
+/**
+ * Thrown when a {@link RemoteResourceFetcher} cannot load a remote resource.
+ */
+public class RemoteResourceFetchException extends Exception {
+
+    private final URI url;
+    private final int statusCode;
+
+    public RemoteResourceFetchException(@NotNull URI url, int statusCode) {
+        super("Remote resource server returned HTTP " + statusCode + " for URL: " + url);
+        this.url = url;
+        this.statusCode = statusCode;
+    }
+
+    public RemoteResourceFetchException(@NotNull URI url, @NotNull String message, @Nullable Throwable cause) {
+        super(message, cause);
+        this.url = url;
+        this.statusCode = -1;
+    }
+
+    @NotNull
+    public URI getUrl() {
+        return url;
+    }
+
+    /**
+     * HTTP status when the server responded; {@code -1} for transport or IO failures.
+     */
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/http/RemoteResourceFetcher.java
+++ b/src/main/java/io/alapierre/ksef/fop/http/RemoteResourceFetcher.java
@@ -1,0 +1,30 @@
+package io.alapierre.ksef.fop.http;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.net.URI;
+
+/**
+ * Pluggable HTTP client for fetching remote template resources (XSLT, logos, labels).
+ * Host applications register an implementation once at startup via
+ * {@link RemoteResourceFetchers#setGlobal(RemoteResourceFetcher)}.
+ * When none is registered, ksef-fop uses {@link HttpURLConnectionRemoteResourceFetcher}.
+ * <p>
+ * <strong>Security:</strong> the host application is responsible for providing a correct,
+ * trustworthy implementation (or relying on the built-in default). A flawed custom fetcher
+ * can undermine containment guarantees — see the README section on remote HTTP fetching.
+ */
+@FunctionalInterface
+public interface RemoteResourceFetcher {
+
+    /**
+     * Performs an HTTP GET for the given absolute URL.
+     * <p>
+     * Implementations must not follow redirects and should enforce a reasonable body size limit.
+     *
+     * @param url absolute {@code http:} or {@code https:} URI
+     * @return response body bytes
+     * @throws RemoteResourceFetchException when the request fails or returns a non-success status
+     */
+    byte @NotNull [] fetch(@NotNull URI url) throws RemoteResourceFetchException;
+}

--- a/src/main/java/io/alapierre/ksef/fop/http/RemoteResourceFetchers.java
+++ b/src/main/java/io/alapierre/ksef/fop/http/RemoteResourceFetchers.java
@@ -1,0 +1,24 @@
+package io.alapierre.ksef.fop.http;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Registry for the active {@link RemoteResourceFetcher}.
+ */
+public final class RemoteResourceFetchers {
+
+    private static volatile RemoteResourceFetcher global = HttpURLConnectionRemoteResourceFetcher.INSTANCE;
+
+    private RemoteResourceFetchers() {
+    }
+
+    @NotNull
+    public static RemoteResourceFetcher get() {
+        return global;
+    }
+
+    public static void setGlobal(@Nullable RemoteResourceFetcher fetcher) {
+        global = fetcher != null ? fetcher : HttpURLConnectionRemoteResourceFetcher.INSTANCE;
+    }
+}

--- a/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoots.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/ResourceRoots.java
@@ -1,5 +1,6 @@
 package io.alapierre.ksef.fop.internal;
 
+import io.alapierre.ksef.fop.http.RemoteResourceFetcher;
 import org.jetbrains.annotations.NotNull;
 
 import javax.xml.transform.TransformerException;
@@ -34,15 +35,22 @@ public final class ResourceRoots {
         return scheme == null || "file".equalsIgnoreCase(scheme);
     }
 
-    public static @NotNull List<ResourceRoot> canonicalize(@NotNull List<URI> roots)
-            throws IOException, TransformerException {
+  /**
+   * Canonicalises resource roots using the supplied HTTP client for remote roots.
+   *
+   * @param fetcher HTTP client for {@code http(s):} roots; must not be {@code null}
+   */
+    public static @NotNull List<ResourceRoot> canonicalize(
+            @NotNull List<URI> roots,
+            @NotNull RemoteResourceFetcher fetcher
+    ) throws IOException, TransformerException {
         List<ResourceRoot> result = new ArrayList<>(roots.size());
         for (URI root : roots) {
             if (root == null) {
                 throw new IllegalArgumentException("Resource root must not be null");
             }
             if (isHttp(root)) {
-                result.add(UrlResourceRoot.canonicalize(root));
+                result.add(UrlResourceRoot.canonicalize(root, fetcher));
             } else if (isFilesystem(root)) {
                 Path canonical = FilesystemRoots.canonicalize(
                         Collections.singletonList(toFilesystemPath(root))).get(0);

--- a/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/TemplateResolver.java
@@ -3,6 +3,8 @@
  */
 package io.alapierre.ksef.fop.internal;
 
+import io.alapierre.ksef.fop.http.RemoteResourceFetcher;
+import io.alapierre.ksef.fop.http.RemoteResourceFetchers;
 import net.sf.saxon.trans.NonDelegatingURIResolver;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -78,8 +80,16 @@ public class TemplateResolver implements NonDelegatingURIResolver {
      * @param roots ordered list of filesystem ({@code file:}) or HTTP(S) base URIs
      */
     public TemplateResolver(List<URI> roots) throws TransformerException {
+        this(roots, RemoteResourceFetchers.get());
+    }
+
+    /**
+     * Constructs a resolver with an explicit HTTP client (primarily for tests).
+     */
+    public TemplateResolver(List<URI> roots, @NotNull RemoteResourceFetcher remoteResourceFetcher)
+            throws TransformerException {
         try {
-            this.resourceRoots = ResourceRoots.canonicalize(roots);
+            this.resourceRoots = ResourceRoots.canonicalize(roots, remoteResourceFetcher);
         } catch (IOException e) {
             throw new TransformerException("Resource root is not accessible: " + e.getMessage(), e);
         }

--- a/src/main/java/io/alapierre/ksef/fop/internal/UrlResourceRoot.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/UrlResourceRoot.java
@@ -114,6 +114,10 @@ final class UrlResourceRoot extends ResourceRoot {
     @NotNull
     Source fetch(@NotNull URI url) throws TransformerException {
         String urlString = url.toString();
+        if (!containsUri(url)) {
+            throw new TransformerException("Remote template URL escapes configured HTTP resource root '"
+                    + baseUri + "': " + urlString);
+        }
         log.debug("XSLT: fetching resource from remote server: {}", urlString);
         try {
             byte[] body = fetcher.fetch(url);

--- a/src/main/java/io/alapierre/ksef/fop/internal/UrlResourceRoot.java
+++ b/src/main/java/io/alapierre/ksef/fop/internal/UrlResourceRoot.java
@@ -1,5 +1,7 @@
 package io.alapierre.ksef.fop.internal;
 
+import io.alapierre.ksef.fop.http.RemoteResourceFetchException;
+import io.alapierre.ksef.fop.http.RemoteResourceFetcher;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -9,13 +11,8 @@ import javax.xml.transform.Source;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,22 +24,24 @@ final class UrlResourceRoot extends ResourceRoot {
 
     private static final Logger log = LoggerFactory.getLogger(UrlResourceRoot.class);
 
-    private static final int REMOTE_TIMEOUT_MS = 10_000;
-    private static final int MAX_REMOTE_BYTES = 16 * 1024 * 1024;
-
     private final URI baseUri;
+    private final RemoteResourceFetcher fetcher;
 
-    private UrlResourceRoot(@NotNull URI baseUri) {
+    private UrlResourceRoot(@NotNull URI baseUri, @NotNull RemoteResourceFetcher fetcher) {
         this.baseUri = baseUri;
+        this.fetcher = fetcher;
     }
 
-    static @NotNull UrlResourceRoot canonicalize(@NotNull URI uri) throws TransformerException {
+    static @NotNull UrlResourceRoot canonicalize(
+            @NotNull URI uri,
+            @NotNull RemoteResourceFetcher fetcher
+    ) throws TransformerException {
         URI normalized = parseHttpUri(uri);
         String host = normalized.getHost();
         if (host == null || host.isEmpty()) {
             throw new TransformerException("HTTP resource root must have a host: " + uri);
         }
-        return new UrlResourceRoot(stripTrailingSlash(normalized));
+        return new UrlResourceRoot(stripTrailingSlash(normalized), fetcher);
     }
 
     @NotNull
@@ -116,31 +115,12 @@ final class UrlResourceRoot extends ResourceRoot {
     Source fetch(@NotNull URI url) throws TransformerException {
         String urlString = url.toString();
         log.debug("XSLT: fetching resource from remote server: {}", urlString);
-        HttpURLConnection connection = null;
         try {
-            connection = (HttpURLConnection) new URL(urlString).openConnection();
-            connection.setConnectTimeout(REMOTE_TIMEOUT_MS);
-            connection.setReadTimeout(REMOTE_TIMEOUT_MS);
-            connection.setInstanceFollowRedirects(false);
-            connection.setRequestProperty("Accept", "application/xslt+xml, text/xml, application/xml, */*");
-            connection.setRequestMethod("GET");
-
-            int status = connection.getResponseCode();
-            if (status != HttpURLConnection.HTTP_OK) {
-                throw new TransformerException(
-                        "Remote resource server returned HTTP " + status + " for URL: " + urlString);
-            }
-
-            byte[] body = readFully(connection.getInputStream());
+            byte[] body = fetcher.fetch(url);
             log.debug("XSLT: fetched {} bytes from {}", body.length, urlString);
             return new StreamSource(new ByteArrayInputStream(body), urlString);
-
-        } catch (IOException e) {
-            throw new TransformerException(
-                    "Failed to fetch remote resource (server may be down): " + urlString
-                            + " — " + e.getMessage(), e);
-        } finally {
-            if (connection != null) connection.disconnect();
+        } catch (RemoteResourceFetchException e) {
+            throw new TransformerException(e.getMessage(), e);
         }
     }
 
@@ -190,20 +170,6 @@ final class UrlResourceRoot extends ResourceRoot {
             return uri;
         }
         return URI.create(s.substring(0, end));
-    }
-
-    private static byte[] readFully(InputStream in) throws IOException, TransformerException {
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        byte[] chunk = new byte[8192];
-        int n;
-        while ((n = in.read(chunk)) != -1) {
-            buf.write(chunk, 0, n);
-            if (buf.size() > MAX_REMOTE_BYTES) {
-                throw new TransformerException("Remote resource exceeds maximum allowed size of "
-                        + MAX_REMOTE_BYTES + " bytes");
-            }
-        }
-        return buf.toByteArray();
     }
 
     @Override

--- a/src/test/java/io/alapierre/ksef/fop/http/RemoteResourceFetchersTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/http/RemoteResourceFetchersTest.java
@@ -1,0 +1,49 @@
+package io.alapierre.ksef.fop.http;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RemoteResourceFetchersTest {
+
+    @AfterEach
+    void tearDown() {
+        RemoteResourceFetchers.setGlobal(null);
+    }
+
+    @Test
+    void get_returnsDefaultWhenNothingRegistered() {
+        assertThat(RemoteResourceFetchers.get())
+                .isSameAs(HttpURLConnectionRemoteResourceFetcher.INSTANCE);
+    }
+
+    @Test
+    void get_returnsRegisteredGlobalFetcher() throws Exception {
+        RemoteResourceFetcher custom = uri -> "custom".getBytes();
+        RemoteResourceFetchers.setGlobal(custom);
+
+        assertThat(RemoteResourceFetchers.get()).isSameAs(custom);
+        assertThat(RemoteResourceFetchers.get().fetch(URI.create("http://example.com/x")))
+                .containsExactly("custom".getBytes());
+    }
+
+    @Test
+    void setGlobal_nullRevertsToDefault() {
+        RemoteResourceFetchers.setGlobal(uri -> new byte[0]);
+        RemoteResourceFetchers.setGlobal(null);
+
+        assertThat(RemoteResourceFetchers.get())
+                .isSameAs(HttpURLConnectionRemoteResourceFetcher.INSTANCE);
+    }
+
+    @Test
+    void defaultFetcher_rejectsNonHttpUrl() {
+        assertThatThrownBy(() ->
+                HttpURLConnectionRemoteResourceFetcher.INSTANCE.fetch(URI.create("ftp://example.com/x")))
+                .isInstanceOf(RemoteResourceFetchException.class);
+    }
+}

--- a/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -212,6 +213,22 @@ class TemplateResolverTest {
                 .isEqualTo(URI.create("http://localhost:8077/xslt/SALES_INVOICE/1234567890/i18n/labels_pl.xml"));
         assertThat(root.resolveRelative("/ksef_invoice.xsl"))
                 .isEqualTo(URI.create("http://localhost:8077/xslt/SALES_INVOICE/1234567890/ksef_invoice.xsl"));
+    }
+
+    @Test
+    void urlResourceRootDoesNotFetchRelativePathEscapingScopedRoot() throws Exception {
+        AtomicBoolean fetcherCalled = new AtomicBoolean(false);
+        RemoteResourceFetcher fetcher = uri -> {
+            fetcherCalled.set(true);
+            return new byte[0];
+        };
+        UrlResourceRoot root = UrlResourceRoot.canonicalize(
+                URI.create("http://localhost:8077/xslt/SALES_INVOICE/1234567890"), fetcher);
+
+        Source source = root.tryResolveRelative("../ksef_invoice.xsl");
+
+        assertThat(source).isNull();
+        assertThat(fetcherCalled).isFalse();
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/internal/TemplateResolverTest.java
@@ -1,5 +1,6 @@
 package io.alapierre.ksef.fop.internal;
 
+import io.alapierre.ksef.fop.http.RemoteResourceFetcher;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -171,8 +172,27 @@ class TemplateResolverTest {
     }
 
     @Test
+    void usesInjectedRemoteResourceFetcherForAbsoluteHttpHref() throws Exception {
+        RemoteResourceFetcher fetcher = uri -> {
+            assertThat(uri.toString()).isEqualTo("http://example.com/xslt/ksef_invoice.xsl");
+            return "<xsl:stylesheet version=\"1.0\"/>".getBytes(StandardCharsets.UTF_8);
+        };
+
+        TemplateResolver resolver = new TemplateResolver(
+                Collections.singletonList(URI.create("http://example.com/xslt")),
+                fetcher
+        );
+
+        Source source = resolver.resolve("http://example.com/xslt/ksef_invoice.xsl", "");
+
+        assertThat(source).isNotNull();
+        assertThat(source.getSystemId()).isEqualTo("http://example.com/xslt/ksef_invoice.xsl");
+    }
+
+    @Test
     void urlResourceRootDetectsPrefixAndExactMatch() throws Exception {
-        UrlResourceRoot root = UrlResourceRoot.canonicalize(URI.create("http://localhost:8077/xslt"));
+        RemoteResourceFetcher unused = uri -> new byte[0];
+        UrlResourceRoot root = UrlResourceRoot.canonicalize(URI.create("http://localhost:8077/xslt"), unused);
         assertThat(root.contains("http://localhost:8077/xslt")).isTrue();
         assertThat(root.contains("http://localhost:8077/xslt/ksef_invoice")).isTrue();
         assertThat(root.contains("http://evil.example/xslt/ksef_invoice")).isFalse();
@@ -181,10 +201,11 @@ class TemplateResolverTest {
 
     @Test
     void urlResourceRootResolvesRelativePathUnderScopedRoot() throws Exception {
+        RemoteResourceFetcher unused = uri -> new byte[0];
         // A scoped root whose last segment (here a NIP) must be preserved: a bare relative href
         // resolves *under* the root rather than replacing the trailing segment.
         UrlResourceRoot root = UrlResourceRoot.canonicalize(
-                URI.create("http://localhost:8077/xslt/SALES_INVOICE/1234567890"));
+                URI.create("http://localhost:8077/xslt/SALES_INVOICE/1234567890"), unused);
         assertThat(root.resolveRelative("ksef_invoice.xsl"))
                 .isEqualTo(URI.create("http://localhost:8077/xslt/SALES_INVOICE/1234567890/ksef_invoice.xsl"));
         assertThat(root.resolveRelative("i18n/labels_pl.xml"))


### PR DESCRIPTION
## Summary

- Extract remote HTTP template fetching from `UrlResourceRoot` into a pluggable `RemoteResourceFetcher` SPI, so host applications can plug in their own HTTP client (e.g. Micronaut `HttpClient`) instead of the built-in `HttpURLConnection` implementation.
- Add `RemoteResourceFetchers` global registry (`setGlobal` / `get`) with `HttpURLConnectionRemoteResourceFetcher` as the default when nothing is registered — behaviour unchanged for existing users.
- Allow explicit fetcher injection in `TemplateResolver` constructor for tests; document integration and security responsibilities (SSRF, redirects, body size limits, TLS) in README.