### PR TITLE
feat: render third party NrID on FA(3) invoice

### DIFF
--- a/src/main/resources/templates/fa3/ksef_invoice.xsl
+++ b/src/main/resources/templates/fa3/ksef_invoice.xsl
@@ -2727,6 +2727,14 @@
                 <fo:inline font-weight="600"><xsl:value-of select="key('kLabels', 'nip', $labels)"/>: </fo:inline>
                 <xsl:value-of select="$id/crd:NIP"/>
             </xsl:if>
+            <xsl:if test="$id/crd:NrID">
+                <fo:inline font-weight="600"><xsl:value-of select="key('kLabels', 'taxId', $labels)"/>: </fo:inline>
+                <xsl:if test="$id/crd:KodKraju">
+                    <xsl:value-of select="$id/crd:KodKraju"/>
+                    <xsl:text> </xsl:text>
+                </xsl:if>
+                <xsl:value-of select="$id/crd:NrID"/>
+            </xsl:if>
             <xsl:if test="crd:DaneIdentyfikacyjne/crd:IDWew">
                 <fo:inline font-weight="600">
                     <xsl:value-of select="key('kLabels', 'idWew', $labels)"/>: </fo:inline>

--- a/src/test/java/io/alapierre/ksef/fop/PodmiotTemplateTest.java
+++ b/src/test/java/io/alapierre/ksef/fop/PodmiotTemplateTest.java
@@ -20,7 +20,8 @@ class PodmiotTemplateTest extends AbstractGeneratePdfTest {
             "enforcement_authority",
             "tax_representative",
             "multiple_rola_inna",
-            "multiple_roles"
+            "multiple_roles",
+            "factor_nr_id"
     })
     void testOptionalNazwaAndAdres(String resource) throws Exception {
         String actual = generateFa3InvoiceText("faktury/PodmiotTemplateTest/" + resource + ".xml");

--- a/src/test/resources/faktury/PodmiotTemplateTest/factor_nr_id-expected.txt
+++ b/src/test/resources/faktury/PodmiotTemplateTest/factor_nr_id-expected.txt
@@ -1,0 +1,30 @@
+Numer faktury
+FV/1/02/2026
+Faktura podstawowa
+Sprzedawca Nabywca
+NIP: 1111111111
+Nazwa: Sprzedawca Sp. z o.o.
+Adres
+ul. Przykładowa 1, 00-001 Warszawa
+POLSKA
+NIP: 2222222222
+Faktor1
+Identyfikator podatkowy inny: DE 123456789
+Adres
+Teststraße 10, 10115 Berlin
+NIEMCY
+1 Faktor - w przypadku gdy na fakturze występują dane faktora
+Szczegóły
+Data wystawienia¹: 2026-02-01
+¹ z zastrzeżeniem art. 106na ust. 1 ustawy
+Faktura wystawiona w cenach netto w walucie PLN
+Pozycje
+Lp. Nazwa towaru lub usługi Ilość Jedn. Cena jedn.
+netto
+Stawka
+podatku
+Wartość
+sprzedaży
+netto
+1 Towar 4 001,49 szt. 1,00 23% 4 001,49
+Kwota należności ogółem: 4 001,49 PLN

--- a/src/test/resources/faktury/PodmiotTemplateTest/factor_nr_id.xml
+++ b/src/test/resources/faktury/PodmiotTemplateTest/factor_nr_id.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Faktura
+        xmlns="http://crd.gov.pl/wzor/2025/06/25/13775/">
+
+    <Naglowek>
+        <KodFormularza kodSystemowy="FA (3)" wersjaSchemy="1-0E">FA</KodFormularza>
+        <WariantFormularza>3</WariantFormularza>
+        <DataWytworzeniaFa>2026-02-01T00:00:00Z</DataWytworzeniaFa>
+    </Naglowek>
+
+    <Podmiot1>
+        <DaneIdentyfikacyjne>
+            <NIP>1111111111</NIP>
+            <Nazwa>Sprzedawca Sp. z o.o.</Nazwa>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>PL</KodKraju>
+            <AdresL1>ul. Przykładowa 1, 00-001 Warszawa</AdresL1>
+        </Adres>
+    </Podmiot1>
+
+    <Podmiot2>
+        <DaneIdentyfikacyjne>
+            <NIP>2222222222</NIP>
+        </DaneIdentyfikacyjne>
+        <JST>2</JST>
+        <GV>2</GV>
+    </Podmiot2>
+
+    <Podmiot3>
+        <DaneIdentyfikacyjne>
+            <KodKraju>DE</KodKraju>
+            <NrID>123456789</NrID>
+        </DaneIdentyfikacyjne>
+        <Adres>
+            <KodKraju>DE</KodKraju>
+            <AdresL1>Teststraße 10, 10115 Berlin</AdresL1>
+        </Adres>
+        <Rola>1</Rola>
+    </Podmiot3>
+
+    <Fa>
+        <KodWaluty>PLN</KodWaluty>
+        <P_1>2026-02-01</P_1>
+        <P_2>FV/1/02/2026</P_2>
+        <P_15>4001.49</P_15>
+
+        <Adnotacje>
+            <P_16>2</P_16>
+            <P_17>2</P_17>
+            <P_18>2</P_18>
+            <P_18A>2</P_18A>
+            <Zwolnienie>
+                <P_19N>1</P_19N>
+            </Zwolnienie>
+            <NoweSrodkiTransportu>
+                <P_22N>1</P_22N>
+            </NoweSrodkiTransportu>
+            <P_23>2</P_23>
+            <PMarzy>
+                <P_PMarzyN>1</P_PMarzyN>
+            </PMarzy>
+        </Adnotacje>
+
+        <RodzajFaktury>VAT</RodzajFaktury>
+
+        <FaWiersz>
+            <NrWierszaFa>1</NrWierszaFa>
+            <P_7>Towar</P_7>
+            <P_8A>szt.</P_8A>
+            <P_8B>4001.49</P_8B>
+            <P_9A>1</P_9A>
+            <P_11>4001.49</P_11>
+            <P_12>23</P_12>
+        </FaWiersz>
+    </Fa>
+
+</Faktura>


### PR DESCRIPTION
### Description

A third party (Podmiot3) on an FA(3) invoice can be identified by NrID, the "other tax identifier" used typically for non-EU entities. Currently the library does not render this number. This PR adds NrID rendering to the FA(3) Podmiot3 template, with an optional KodKraju prefix.

### Testing

Pr adds a new invoice example to test/resources/faktury/PodmiotTemplateTest, with a third party that has NrID present.
The functionality is checked using existing PodmiotTemplateTest.